### PR TITLE
Set eol to 'LF' in tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,8 @@
     "experimentalDecorators": true,
     "resolveJsonModule": true,
     "skipLibCheck": true,
-    "pretty": true
+    "pretty": true,
+    "newLine": "lf"
   },
   "exclude": [
     "src/test.ts",


### PR DESCRIPTION
Execute `yarn tsc-alias` on github actions (ubuntu-latest) will get errors: "/usr/bin/env: ‘node\r’: No such file or directory".

According to [https://github.com/yarnpkg/yarn/issues/8106](https://github.com/yarnpkg/yarn/issues/8106), a possible reason is that the current tsc-alias release use `CRLF` as line endings.

So change it to `LF` by adding `newLine` property in tsconfig.