### PR TITLE
Support empty relative alias paths

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -180,7 +180,12 @@ export function replaceTscAliasPaths(
       );
 
       if (relativeAliasPath[0] !== '.') {
-        relativeAliasPath = './' + relativeAliasPath;
+        if (relativeAliasPath.length === 0) {
+          relativeAliasPath = '.'
+        }
+        else {
+          relativeAliasPath = './' + relativeAliasPath;
+        }
       }
 
       const modulePath =


### PR DESCRIPTION
Fixes an issue that causes path aliases for `./` to get incorrectly rewritten to `.//*` instead of `./*`.

Given the following `tsconfig.json`:

```json
"baseUrl": "./src",
"paths": {
  "my-app": ["./"],
  "my-app/*": ["./*"]
}
```

The current code will rewrite `my-app/Foo` to `.//Foo` instead of `./Foo`.

This PR fixes the issue, rewriting the path to  `./Foo`.