### PR TITLE
add support for scoped package alias

### DIFF
--- a/projects/project5/package.json
+++ b/projects/project5/package.json
@@ -1,0 +1,7 @@
+{
+  "private": true,
+  "scripts": {
+    "build": "tsc && tsc-alias",
+    "start": "npm run build && node ./dist/project5/src/index.js"
+  }
+}

--- a/projects/project5/src/custom_modules/calculator.ts
+++ b/projects/project5/src/custom_modules/calculator.ts
@@ -1,0 +1,3 @@
+export function add(a: number, b: number) {
+  return a + b;
+}

--- a/projects/project5/src/custom_modules/index.ts
+++ b/projects/project5/src/custom_modules/index.ts
@@ -1,0 +1,1 @@
+export const CUSTOM_MODULE = 'custom module';

--- a/projects/project5/src/index.ts
+++ b/projects/project5/src/index.ts
@@ -1,0 +1,11 @@
+import { DATA } from '@commons';
+import { CUSTOM_MODULE } from 'custom/index';
+import { EXTRA } from 'extra';
+import { add } from 'myproject/custom_modules/calculator';
+import { SCOPE } from '@me/myproject/scope/index';
+
+console.log(DATA);
+console.log(CUSTOM_MODULE);
+console.log(EXTRA);
+console.log(add(1, 2));
+console.log(SCOPE);

--- a/projects/project5/src/lib/commons/index.ts
+++ b/projects/project5/src/lib/commons/index.ts
@@ -1,0 +1,1 @@
+export const DATA = 'mydata';

--- a/projects/project5/src/scope/index.ts
+++ b/projects/project5/src/scope/index.ts
@@ -1,0 +1,1 @@
+export const SCOPE = 'me';

--- a/projects/project5/tsconfig.json
+++ b/projects/project5/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "@jkm/tsconfig", /* from node_modules */
+  "compilerOptions": {
+    "outDir": "dist",
+    "target": "es5",
+    "module": "commonjs",
+    "strictNullChecks": false,
+    "noImplicitAny": false,
+    "baseUrl": "./src",
+    "paths": {
+      "myproject/*": ["./*"],
+      "@me/myproject/*": ["./*"],
+      "@commons": ["lib/commons/index.ts"],
+      "custom/*": ["custom_modules/*"],
+      "extra": ["../../project2/index"]
+    }
+  },
+  "exclude": ["node_modules"]
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,13 +9,13 @@ import {
   isAbsolute,
   normalize,
   relative,
-  resolve,
+  resolve
 } from 'path';
 import {
   existsResolvedAlias,
   getAbsoluteAliasPath,
   getProjectDirPathInOutDir,
-  loadConfig,
+  loadConfig
 } from './helpers';
 
 export function replaceTscAliasPaths(
@@ -24,8 +24,8 @@ export function replaceTscAliasPaths(
     outDir?: string;
     watch?: boolean;
   } = {
-    watch: false,
-  }
+      watch: false,
+    }
 ) {
   Output.info('=== tsc-alias starting ===');
   if (!options.configFile) {
@@ -130,10 +130,9 @@ export function replaceTscAliasPaths(
     if (normalize(alias.path).includes('..')) {
       const tempBasePath = normalizePath(
         normalize(
-          `${configDir}/${outDir}/${
-            hasExtraModule && relConfDirPathInOutPath
-              ? relConfDirPathInOutPath
-              : ''
+          `${configDir}/${outDir}/${hasExtraModule && relConfDirPathInOutPath
+            ? relConfDirPathInOutPath
+            : ''
           }/${baseUrl}`
         )
       );
@@ -175,7 +174,7 @@ export function replaceTscAliasPaths(
   }): string => {
     const requiredModule = orig.split(/"|'/)[1];
     const index = orig.indexOf(alias.prefix);
-    const isAlias = requiredModule.split('/').indexOf(alias.prefix) === 0;
+    const isAlias = requiredModule.startsWith(alias.prefix);
     if (index > -1 && isAlias) {
       let absoluteAliasPath = getAbsoluteAliasPath(alias.basePath, alias.path);
       let relativeAliasPath: string = normalizePath(

--- a/tests/test.spec.ts
+++ b/tests/test.spec.ts
@@ -3,7 +3,7 @@ import * as shell from 'shelljs';
 
 const projectsRoot = join(__dirname, '../projects');
 
-[1, 3, 4].forEach((value) => {
+[1, 3, 4, 5].forEach((value) => {
   it(`Project ${value}`, () => {
     const { code, stderr } = shell.exec('npm start', {
       cwd: join(projectsRoot, `project${value}`),


### PR DESCRIPTION
resolve #18 

Regarding `const isAlias = requiredModule.split('/').indexOf(alias.prefix) === 0;` in the change, split(/) does not do the job when it comes to the scoped package but it looks to me that `const isAlias = requiredModule.startsWith(alias.prefix);` is equivalent to it while it fixes the issue so I believe this one-line-change is backward compatible. :)

