### PR TITLE
Fix wrong watch script example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ npm install --save-dev tsc-alias
 
 "scripts": {
   "build": "tsc && tsc-alias",
-  "build:watch": "tsc -w && tsc-alias -w"
+  "build:watch": "tsc -w & tsc-alias -w"
 }
 ```
 


### PR DESCRIPTION
It seems watch script example is wrong.
Currently using "&&" So "tsc-alias -w" is not parallel running.
I tested and check completely works this fix on my own project.