### PR TITLE
Add option to fully resolve paths, making compiled code ECMAScript Module-ready

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,11 @@ Here are all the available options:
       <td><code>tsconfig.compilerOptions.outDir</code></td>
     </tr>
     <tr>
+      <td>resolveFullPaths</td>
+      <td>Attempt to replace incomplete import paths (those not ending in <code>.js</code>) with fully resolved paths (for ECMAScript Modules compatibility)</td>
+      <td><code>false</code></td>
+    </tr>
+    <tr>
       <td>silent</td>
       <td>Reduced terminal output</td>
       <td><code>false</code></td>

--- a/projects/project10/package.json
+++ b/projects/project10/package.json
@@ -1,0 +1,7 @@
+{
+  "private": true,
+  "scripts": {
+    "build": "tsc && tsc-alias --resolve-full-paths",
+    "start": "npm run build && node ./dist/main.js"
+  }
+}

--- a/projects/project10/src/api/invoice/invoice.service.ts
+++ b/projects/project10/src/api/invoice/invoice.service.ts
@@ -1,0 +1,5 @@
+import { getdateString } from '@/utils';
+
+export function generateInvoice() {
+  getdateString(new Date());
+}

--- a/projects/project10/src/main.ts
+++ b/projects/project10/src/main.ts
@@ -1,0 +1,3 @@
+import { generateInvoice } from './api/invoice/invoice.service';
+
+generateInvoice();

--- a/projects/project10/src/utils/index.ts
+++ b/projects/project10/src/utils/index.ts
@@ -1,0 +1,3 @@
+export function getdateString(date: Date) {
+  return date.toString();
+}

--- a/projects/project10/tsconfig.json
+++ b/projects/project10/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "resolveJsonModule": true,
+    "module": "commonjs",
+    "declaration": true,
+    "removeComments": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "allowSyntheticDefaultImports": true,
+    "target": "es2017",
+    "outDir": "./dist",
+    "baseUrl": "./",
+    "paths": {
+      "@/*": ["src/*"]
+    }
+  },
+  "include": ["src"]
+}

--- a/projects/project11/package-lock.json
+++ b/projects/project11/package-lock.json
@@ -1,0 +1,12 @@
+{
+  "requires": true,
+  "lockfileVersion": 1,
+  "dependencies": {
+    "@tsconfig/node14": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.0.tgz",
+      "integrity": "sha512-RKkL8eTdPv6t5EHgFKIVQgsDapugbuOptNd9OOunN/HAkzmmTnZELx1kNCK0rSdUYGmiFMM3rRQMAWiyp023LQ==",
+      "dev": true
+    }
+  }
+}

--- a/projects/project11/package.json
+++ b/projects/project11/package.json
@@ -1,0 +1,10 @@
+{
+  "private": true,
+  "scripts": {
+    "build": "npm i && tsc && tsc-alias --resolve-full-paths",
+    "start": "npm run build && node ./dist/project11/src/index.js"
+  },
+  "devDependencies": {
+    "@tsconfig/node14": "^1.0.0"
+  }
+}

--- a/projects/project11/src/custom_modules/calculator.ts
+++ b/projects/project11/src/custom_modules/calculator.ts
@@ -1,0 +1,3 @@
+export function add(a: number, b: number) {
+  return a + b;
+}

--- a/projects/project11/src/custom_modules/index.ts
+++ b/projects/project11/src/custom_modules/index.ts
@@ -1,0 +1,1 @@
+export const CUSTOM_MODULE = 'custom module';

--- a/projects/project11/src/index.ts
+++ b/projects/project11/src/index.ts
@@ -1,0 +1,7 @@
+import { CUSTOM_MODULE } from 'custom/index';
+import { EXTRA } from 'extra';
+import { add } from 'myproject/custom_modules/calculator';
+
+console.log(CUSTOM_MODULE);
+console.log(EXTRA);
+console.log(add(1, 2));

--- a/projects/project11/tsconfig.json
+++ b/projects/project11/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "@tsconfig/node14" /* from node_modules */,
+  "compilerOptions": {
+    "outDir": "dist",
+    "target": "es5",
+    "module": "commonjs",
+    "strictNullChecks": false,
+    "noImplicitAny": false,
+    "baseUrl": "./src",
+    "paths": {
+      "myproject/*": ["./*"],
+      "custom/*": ["custom_modules/*"],
+      "extra": ["../../project2/index"]
+    },
+    "resolveJsonModule": true
+  },
+  "exclude": ["node_modules"]
+}

--- a/projects/project9/package-lock.json
+++ b/projects/project9/package-lock.json
@@ -1,0 +1,80 @@
+{
+  "requires": true,
+  "lockfileVersion": 1,
+  "dependencies": {
+    "@esfx/collection-core": {
+      "version": "1.0.0-pre.17",
+      "resolved": "https://registry.npmjs.org/@esfx/collection-core/-/collection-core-1.0.0-pre.17.tgz",
+      "integrity": "sha512-dzaw35wkW/tzbLtbxRGU5laNxAejGNVY83Snj7gJie3lQ4HefJ0CPYzeLWN2JvMc6G4ut5kmfGfyXvVIyKQKxw==",
+      "requires": {
+        "@esfx/internal-deprecate": "^1.0.0-pre.17",
+        "@esfx/internal-guards": "^1.0.0-pre.17"
+      }
+    },
+    "@esfx/collections-hashmap": {
+      "version": "1.0.0-pre.17",
+      "resolved": "https://registry.npmjs.org/@esfx/collections-hashmap/-/collections-hashmap-1.0.0-pre.17.tgz",
+      "integrity": "sha512-cptgCpDX7JDY0Y+vlzJ7b4T1iaEvOIWbqThaTI7zdWuWS8fmOpcJGXtCoDmT2VdMWFA+VRVveOqETggUo2S+RQ==",
+      "requires": {
+        "@esfx/collection-core": "^1.0.0-pre.17",
+        "@esfx/equatable": "^1.0.0-pre.17",
+        "@esfx/internal-collections-hash": "^1.0.0-pre.17",
+        "@esfx/internal-guards": "^1.0.0-pre.17"
+      }
+    },
+    "@esfx/equatable": {
+      "version": "1.0.0-pre.17",
+      "resolved": "https://registry.npmjs.org/@esfx/equatable/-/equatable-1.0.0-pre.17.tgz",
+      "integrity": "sha512-VzHDMmVj2JsE75yBDL2H6h0BcxSQLdYCYD7KomXxa2BuJvhbOabPOTyapy7+ECzyHrffnNVzFbGs+At3xdGbEw==",
+      "requires": {
+        "@esfx/internal-deprecate": "^1.0.0-pre.17",
+        "@esfx/internal-hashcode": "^1.0.0-pre.17"
+      }
+    },
+    "@esfx/internal-collections-hash": {
+      "version": "1.0.0-pre.17",
+      "resolved": "https://registry.npmjs.org/@esfx/internal-collections-hash/-/internal-collections-hash-1.0.0-pre.17.tgz",
+      "integrity": "sha512-WEbMFcjpA5jKA3E7Tplz2uVmAufhnlA7lcEl+t6GYLFocBBx92CwDB3PYbYVyBtB5Dcj3G3YtqlcBQaOjEmoaw==",
+      "requires": {
+        "@esfx/equatable": "^1.0.0-pre.17",
+        "@esfx/internal-integers": "^1.0.0-pre.17"
+      }
+    },
+    "@esfx/internal-deprecate": {
+      "version": "1.0.0-pre.17",
+      "resolved": "https://registry.npmjs.org/@esfx/internal-deprecate/-/internal-deprecate-1.0.0-pre.17.tgz",
+      "integrity": "sha512-91dsKj+a5HQuzxnuFuQGOVQK9uLNRvpAeUapFyIDSBC2ARjHvUBcTDlRaQvP7f0qhiHivWn/I6mA3IgUgDptnA=="
+    },
+    "@esfx/internal-guards": {
+      "version": "1.0.0-pre.17",
+      "resolved": "https://registry.npmjs.org/@esfx/internal-guards/-/internal-guards-1.0.0-pre.17.tgz",
+      "integrity": "sha512-QzDEALC/eVhee+7Rk/9IKLJ7afzD08CqqYcOdE/6K9BOR18rBMxadDZ+0dCkVyLYhz2iNynAh8a3IAEBFfx3Sw==",
+      "requires": {
+        "@esfx/type-model": "^1.0.0-pre.17"
+      }
+    },
+    "@esfx/internal-hashcode": {
+      "version": "1.0.0-pre.17",
+      "resolved": "https://registry.npmjs.org/@esfx/internal-hashcode/-/internal-hashcode-1.0.0-pre.17.tgz",
+      "integrity": "sha512-plMkjPEKlVjjfaHjh9J5VKDDpKLNhJOwuB94coWYLx/PkxgPpbYW7lUiWi6TwunxxjcF0dQa4EIk24HejvNmmw==",
+      "requires": {
+        "@esfx/internal-murmur3": "^1.0.0-pre.17"
+      }
+    },
+    "@esfx/internal-integers": {
+      "version": "1.0.0-pre.17",
+      "resolved": "https://registry.npmjs.org/@esfx/internal-integers/-/internal-integers-1.0.0-pre.17.tgz",
+      "integrity": "sha512-VUh5O/3wwUBoUC3KcUZSSk48EDdY7AtWUf8NgaelFJjOC7KxZ2e6HFfvyBflannttAYSfomv0mdvvJt3/IE6dA=="
+    },
+    "@esfx/internal-murmur3": {
+      "version": "1.0.0-pre.17",
+      "resolved": "https://registry.npmjs.org/@esfx/internal-murmur3/-/internal-murmur3-1.0.0-pre.17.tgz",
+      "integrity": "sha512-AHTmhvM663suNCaj3Xak0OrXFifb2QNdMJh4/VRP5cnfja7jwRaYka/3VtG5DR4JXgzc1cZ+E87ZFF/SkojcWw=="
+    },
+    "@esfx/type-model": {
+      "version": "1.0.0-pre.17",
+      "resolved": "https://registry.npmjs.org/@esfx/type-model/-/type-model-1.0.0-pre.17.tgz",
+      "integrity": "sha512-jJfiYUD1ntLme6uxDol7McJZ2wfZkLHw0nEuHwyGNn99oL29U0aO+xNGhDQs9Lr5ytF1NbXojFiAxVmgRfBPzA=="
+    }
+  }
+}

--- a/projects/project9/package.json
+++ b/projects/project9/package.json
@@ -1,0 +1,10 @@
+{
+  "private": true,
+  "scripts": {
+    "build": "npm i && tsc && tsc-alias --resolve-full-paths",
+    "start": "npm run build && node ./dist/index.js"
+  },
+  "dependencies": {
+    "@esfx/collections-hashmap": "^1.0.0-pre.17"
+  }
+}

--- a/projects/project9/src/index.ts
+++ b/projects/project9/src/index.ts
@@ -1,0 +1,3 @@
+import { HashMap } from '@esfx/collections-hashmap';
+
+const map = new HashMap();

--- a/projects/project9/tsconfig.json
+++ b/projects/project9/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "outDir": "dist",
+    "baseUrl": "./src",
+    "paths": {
+      "@/*": [
+        "./*",
+      ],
+    },
+  },
+}

--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -13,6 +13,10 @@ program
     '--dir, --directory <dir>',
     'Run in a folder leaving the "outDir" of the tsconfig.json (relative path to tsconfig)'
   )
+  .option(
+    '-f, --resolve-full-paths',
+    'Attempt to fully resolve import paths if the corresponding .js file can be found'
+  )
   .option('-s, --silent', 'reduced terminal output')
   .parse(process.argv);
 
@@ -20,5 +24,6 @@ replaceTscAliasPaths({
   configFile: program.project,
   watch: !!program.watch,
   outDir: program.directory,
-  silent: program.silent
+  silent: program.silent,
+  resolveFullPaths: program.resolveFullPaths
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,11 @@ import {
   getProjectDirPathInOutDir,
   loadConfig
 } from './helpers';
-import { Output, resolveFullImportPaths } from './utils';
+import {
+  Output,
+  resolveFullImportPaths,
+  replaceSourceImportPaths
+} from './utils';
 
 export interface ReplaceTscAliasPathsOptions {
   configFile?: string;
@@ -168,9 +172,6 @@ export function replaceTscAliasPaths(
     }
   });
 
-  const requireRegex = /(?:import|require)\(['"]([^'"]*)['"]\)/g;
-  const importRegex = /(?:import|from) ['"]([^'"]*)['"]/g;
-
   const replaceImportStatement = ({
     orig,
     file,
@@ -213,19 +214,12 @@ export function replaceTscAliasPaths(
         file,
         alias
       };
-      tempCode = tempCode
-        .replace(requireRegex, (orig) =>
-          replaceImportStatement({
-            orig,
-            ...replacementParams
-          })
-        )
-        .replace(importRegex, (orig) =>
-          replaceImportStatement({
-            orig,
-            ...replacementParams
-          })
-        );
+      tempCode = replaceSourceImportPaths(tempCode, file, (orig) =>
+        replaceImportStatement({
+          orig,
+          ...replacementParams
+        })
+      );
     }
 
     // Fully resolve all import paths (not just aliased ones)

--- a/src/utils/ImportPathResolver.ts
+++ b/src/utils/ImportPathResolver.ts
@@ -1,0 +1,150 @@
+/**
+ * @file
+ *
+ * Import statements come in a lot of flavors, so having a single
+ * regex that can capture all of those with minimal side effects
+ * is trickly. In this file this regex is constructed from multiple parts.
+ *
+ * Using a named captured group (supported in ES2018/Node 10+)
+ * to allow arbitrary complexity of the regex without worrying
+ * about messing up indexing.
+ *
+ * Meant to match ESM/CommonJS import patterns.
+ *
+ * ⚠ Can match content of strings and comments!
+ *
+ * @example
+ * // Examples of import statements that must be matched
+ * // (Note that there could be newlines between tokens.)
+ * const module = require('some/path')
+ * import module from 'some/path'
+ * import "some/path"
+ * import theDefault, {namedExport} from 'some/path'
+ * const asyncImport = await import('some/path')
+ * export * from 'some/path';
+ */
+
+/** */
+import { existsSync } from 'fs';
+import * as normalizePath from 'normalize-path';
+import { resolve, join, dirname } from 'path';
+
+export type StringReplacer = (importStatement: string) => string;
+
+const anyQuote = '["\'`]';
+const notQuote = '[^"\'`]';
+const importString = `(?:${anyQuote}${notQuote}+${anyQuote})`;
+
+// Separate patterns for each style of import statement,
+// wrapped in non-capturing groups,
+// so that they can be strung together in one big pattern.
+const funcStyle = `(?:\\b(?:import|require)\\s*\\(\\s*${importString}\\s*\\))`;
+const globalStyle = `(?:\\bimport\\s+${importString})`;
+const fromStyle = `(?:\\bfrom\\s+${notQuote}*?${importString})`;
+
+const importRegexString = `(?:${[funcStyle, globalStyle, fromStyle].join(
+  '|'
+)})`;
+
+class ImportPathResolver {
+  constructor(public source: string, readonly sourcePath: string) {}
+
+  get sourceDir() {
+    return dirname(this.sourcePath);
+  }
+
+  /**
+   * Replace all source import paths, using a replacer
+   * function (a la `String.prototype.replace(globalRegex,replacer)`)
+   */
+  replaceSourceImportPaths(replacer: StringReplacer) {
+    this.source = this.source.replace(
+      ImportPathResolver.newImportStatementRegex('g'),
+      replacer
+    );
+    return this;
+  }
+
+  /**
+   * For a JavaScript code string, find all local import paths
+   * and resolve them to full filenames (including the .js extension).
+   * If no matching file is found for a path, leave it alone.
+   */
+  resolveFullImportPaths() {
+    this.replaceSourceImportPaths((importStatement) => {
+      // Find substring that is just quotes
+      const importPathMatch = importStatement.match(
+        ImportPathResolver.newStringRegex()
+      );
+      if (!importPathMatch) {
+        return importStatement;
+      }
+      const { path, pathWithQuotes } = importPathMatch.groups;
+      const fullPath = normalizePath(this.resolveFullPath(path));
+      return importStatement.replace(
+        pathWithQuotes,
+        pathWithQuotes.replace(path, fullPath)
+      );
+    });
+    return this;
+  }
+
+  /**
+   * Given an import path, resolve the full path (including extension).
+   * If no corresponding file can be found, return the original path.
+   */
+  private resolveFullPath(importPath: string) {
+    if (importPath.match(/\.js$/)) {
+      return importPath;
+    }
+    // Try adding the extension (if not obviously a directory)
+    if (!importPath.match(/[/\\]$/)) {
+      const asFilePath = `${importPath}.js`;
+      if (existsSync(resolve(this.sourceDir, asFilePath))) {
+        return asFilePath;
+      }
+    }
+    // Assume the path is a folder; try adding index.js
+    const asFilePath = join(importPath, 'index.js');
+    if (existsSync(resolve(this.sourceDir, asFilePath))) {
+      return asFilePath;
+    }
+    return importPath;
+  }
+
+  static newStringRegex() {
+    return new RegExp(
+      `(?<pathWithQuotes>${anyQuote}(?<path>${notQuote}+)${anyQuote})`
+    );
+  }
+
+  static newImportStatementRegex(flags = '') {
+    return new RegExp(importRegexString, flags);
+  }
+
+  static resolveFullImportPaths(code: string, path: string) {
+    return new ImportPathResolver(code, path).resolveFullImportPaths().source;
+  }
+
+  static replaceSourceImportPaths(
+    code: string,
+    path: string,
+    replacer: StringReplacer
+  ) {
+    return new ImportPathResolver(code, path).replaceSourceImportPaths(replacer)
+      .source;
+  }
+}
+
+// Export aliases for the static functions
+// to make usage more friendly.
+
+export const resolveFullImportPaths = ImportPathResolver.resolveFullImportPaths;
+
+export const newImportStatementRegex =
+  ImportPathResolver.newImportStatementRegex;
+
+export const replaceSourceImportPaths =
+  ImportPathResolver.replaceSourceImportPaths;
+
+export const newStringRegex = ImportPathResolver.newStringRegex;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,1 +1,2 @@
 export * from './output';
+export * from './ImportPathResolver';

--- a/tests/test.spec.ts
+++ b/tests/test.spec.ts
@@ -1,18 +1,78 @@
 import { join } from 'path';
 import * as rimraf from 'rimraf';
 import * as shell from 'shelljs';
+import { newImportStatementRegex, newStringRegex } from '../dist/utils';
 
 const projectsRoot = join(__dirname, '../projects');
 
-[1, 3, 4, 5, 6, 7, 8].forEach((value) => {
-  it(`Project ${value}`, () => {
-    const projectDir = join(projectsRoot, `project${value}`);
-    rimraf.sync(join(projectDir, 'dist'));
-    const { code, stderr } = shell.exec('npm start', {
-      cwd: projectDir,
-      silent: true
-    });
-    if (code !== 0) console.error(stderr);
-    expect(code).toEqual(0);
+/**
+ * Sample JavaScript code with a bunch of require/import
+ * statements with various spacing etc. Import paths from
+ * valid statements are incrementing numbers, starting from 0,
+ * so that it is easy to verify validity of results.
+ */
+const sampleImportStatements = `
+const module = require('0')
+var module = require
+(
+  '1'
+)  ;
+import module from ('2');
+import "3"
+
+imported ("invalid/import")
+
+import theDefault, {namedExport} from ("4")
+import {
+  extraLinesOhNo
+} from '5'
+const asyncImport = await import('6');
+
+export * from '7';
+
+import
+
+  '8'
+
+const notAnImport = unimport('something');
+`;
+
+function runTestProject(projectNumber: number) {
+  const projectDir = join(projectsRoot, `project${projectNumber}`);
+  rimraf.sync(join(projectDir, 'dist'));
+  const { code, stderr } = shell.exec('npm start', {
+    cwd: projectDir,
+    silent: true
+  });
+  if (code !== 0) console.error(stderr);
+  expect(code).toEqual(0);
+}
+
+it(`Import regex matches import statements`, () => {
+  const expectedImportPaths = sampleImportStatements.match(
+    /(\d+)/g
+  ) as string[];
+
+  const importStatementMatches = sampleImportStatements.match(
+    newImportStatementRegex('g')
+  );
+  expect(importStatementMatches).toHaveLength(expectedImportPaths.length);
+
+  const foundImportPaths: string[] = [];
+  for (const importStatement of importStatementMatches) {
+    // Global match is a string, not a match group, so re-match without the global flag.
+    const pathMatch = importStatement.match(newStringRegex());
+    expect(pathMatch).toBeTruthy();
+    foundImportPaths.push(pathMatch.groups.path);
+  }
+  expectedImportPaths.forEach((expectedPath, i) => {
+    expect(expectedPath).toEqual(foundImportPaths[i]);
+  });
+});
+
+// Run tests on projects. 9-11 are for testing fullpath file resolution
+[1, 3, 4, 5, 6, 7, 8, 9, 10, 11].forEach((value) => {
+  it(`Project ${value} runs after alias resolution`, () => {
+    runTestProject(value);
   });
 });


### PR DESCRIPTION
Typescript configs allow for both path aliases and node-style module resolution, while not fully supporting either on compile due to not modifying import paths.

`tsc-alias` handles the path aliases part of this problem, but not the overlapping module-resolution problem.

When using ECMAScript modules (ESM) in Node, being able to write in Typescript without full resolution is nice but the compiled JavaScript cannot run because ESM requires full paths.

The new feature attempts to find all import paths and then attempts to resolve them to an existing JavaScript file. If found, it replaces the original with the fully-resolved path.

While this could be done as a standalone tool, being able to use a single tool to resolve path issues in tsc-compiled code would be useful.

Additional changes:

- Refactor of the test suite to make room for alternative test commands
- Addition of tests for import-path-matching regexes
- Addition of a class and new import-path-matching regex allowing for a single regex to match all styles of import
- Cloned 3 of the test projects and changed their `tsc-alias` call to include the new `--resolve-full-paths` flag, so that there are test cases for this new feature.

The 2nd commit removes the two-regex matching used by the alias resolver and replaces it with the single-regex pattern. The new pattern does not *exactly* match the use of the original two patterns, but the new pattern successfully matches all test cases so it should not create surprises.