### PR TITLE
Ensures the process exits with non-zero status even if logging is turned off.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,8 @@ export interface ReplaceTscAliasPathsOptions {
   resolveFullPaths?: boolean;
 }
 
+type Assertion = (claim: any, message: string) => asserts claim;
+
 export function replaceTscAliasPaths(
   options: ReplaceTscAliasPathsOptions = {
     watch: false,
@@ -49,24 +51,18 @@ export function replaceTscAliasPaths(
 
   const configFile = options.configFile;
 
-  if (!existsSync(configFile)) {
-    output.error(`Invalid file path => ${configFile}`, true);
-  }
+  const assert: Assertion = (claim, message) =>
+    claim || output.error(message, true);
+
+  assert(existsSync(configFile), `Invalid file path => ${configFile}`);
 
   let { baseUrl, outDir, paths } = loadConfig(configFile);
   if (options.outDir) {
     outDir = options.outDir;
   }
-
-  if (!baseUrl) {
-    output.error('compilerOptions.baseUrl is not set', true);
-  }
-  if (!paths) {
-    output.error('compilerOptions.paths is not set', true);
-  }
-  if (!outDir) {
-    output.error('compilerOptions.outDir is not set', true);
-  }
+  assert(baseUrl, 'compilerOptions.baseUrl is not set');
+  assert(paths, 'compilerOptions.paths is not set');
+  assert(outDir, 'compilerOptions.outDir is not set');
 
   const configDir: string = normalizePath(dirname(configFile));
 

--- a/src/utils/output.ts
+++ b/src/utils/output.ts
@@ -3,14 +3,25 @@ import { Output as Console } from '@jfonx/console-utils';
 export class Output {
   constructor(private silent = false) {}
 
+  /**
+   * Crash the process with a non-zero exit code
+   */
+  private static exitProcessWithError() {
+    process.exit(1);
+  }
+
   info(message: string) {
     if (this.silent) return;
     Console.info(message);
   }
 
-  error(message: string, exitProces = false) {
-    if (this.silent) return;
-    Console.error(message, exitProces);
+  error(message: string, exitProcess = false) {
+    if (!this.silent) {
+      Console.error(message);
+    }
+    if (exitProcess) {
+      Output.exitProcessWithError();
+    }
   }
 
   clear() {


### PR DESCRIPTION
Fixes #32

Additionally adds minor refactor of entrypoint to convert validator code into single-line assertions.

(Note that I originally wanted to have the assertion be part of the `Output` class, but Typescript gets weird about class methods used as assertion functions.)