### PR TITLE
Remove backticks from allowed quote characters for import strings

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,8 @@ import {
 import {
   Output,
   resolveFullImportPaths,
-  replaceSourceImportPaths
+  replaceSourceImportPaths,
+  newStringRegex
 } from './utils';
 
 export interface ReplaceTscAliasPathsOptions {
@@ -177,7 +178,11 @@ export function replaceTscAliasPaths(
     file: string;
     alias: typeof aliases[0];
   }): string => {
-    const requiredModule = orig.split(/"|'/)[1];
+    const requiredModule = orig.match(newStringRegex())?.groups?.path;
+    assert(
+      typeof requiredModule == 'string',
+      `Unexpected import statement pattern ${orig}`
+    );
     const index = orig.indexOf(alias.prefix);
     const isAlias = requiredModule.includes('/')
       ? requiredModule.startsWith(alias.prefix + '/')

--- a/src/utils/ImportPathResolver.ts
+++ b/src/utils/ImportPathResolver.ts
@@ -31,8 +31,8 @@ import { resolve, join, dirname } from 'path';
 
 export type StringReplacer = (importStatement: string) => string;
 
-const anyQuote = '["\'`]';
-const notQuote = '[^"\'`]';
+const anyQuote = '["\']';
+const notQuote = '[^"\']';
 const importString = `(?:${anyQuote}${notQuote}+${anyQuote})`;
 
 // Separate patterns for each style of import statement,


### PR DESCRIPTION
I originally added these because they're *technically* allowed, but probably don't work for ESM-style imports and Typescript doesn't like them. Including it probably hurts more than it helps.

I also coupled the search patterns used in various spots so that they're centralized.

Finally, I added an error log for the Issue #34 just in case this doesn't fix it, since that will help triangulate the problem.