### PR TITLE
Make path-matching regexes more strict to reduce spurious matches

### DIFF
--- a/src/utils/ImportPathResolver.ts
+++ b/src/utils/ImportPathResolver.ts
@@ -32,15 +32,15 @@ import { resolve, join, dirname } from 'path';
 export type StringReplacer = (importStatement: string) => string;
 
 const anyQuote = '["\']';
-const notQuote = '[^"\']';
-const importString = `(?:${anyQuote}${notQuote}+${anyQuote})`;
+const pathStringContent = `[^"'\r\n]+`;
+const importString = `(?:${anyQuote}${pathStringContent}${anyQuote})`;
 
 // Separate patterns for each style of import statement,
 // wrapped in non-capturing groups,
 // so that they can be strung together in one big pattern.
 const funcStyle = `(?:\\b(?:import|require)\\s*\\(\\s*${importString}\\s*\\))`;
 const globalStyle = `(?:\\bimport\\s+${importString})`;
-const fromStyle = `(?:\\bfrom\\s+${notQuote}*?${importString})`;
+const fromStyle = `(?:\\bfrom\\s+${importString})`;
 
 const importRegexString = `(?:${[funcStyle, globalStyle, fromStyle].join(
   '|'
@@ -114,7 +114,7 @@ class ImportPathResolver {
 
   static newStringRegex() {
     return new RegExp(
-      `(?<pathWithQuotes>${anyQuote}(?<path>${notQuote}+)${anyQuote})`
+      `(?<pathWithQuotes>${anyQuote}(?<path>${pathStringContent})${anyQuote})`
     );
   }
 

--- a/tests/test.spec.ts
+++ b/tests/test.spec.ts
@@ -17,12 +17,13 @@ var module = require
 (
   '1'
 )  ;
-import module from ('2');
+import module from '2';
 import "3"
 
 imported ("invalid/import")
 
-import theDefault, {namedExport} from ("4")
+import theDefault, {namedExport} from
+    "4"
 import {
   extraLinesOhNo
 } from '5'
@@ -68,6 +69,17 @@ it(`Import regex matches import statements`, () => {
   expectedImportPaths.forEach((expectedPath, i) => {
     expect(expectedPath).toEqual(foundImportPaths[i]);
   });
+});
+
+it(`Import regex does not match edge cases from keywords in strings`, function () {
+  const testCase = `
+    'a string with keyword from '
+    // The from keyword in that string can cause
+    // a match up to the next quote, since the regex does not
+    // know that the keyword is in a string context
+    'another string using same quote type'
+  `;
+  expect(newImportStatementRegex().exec(testCase)?.[0]).toBeUndefined();
 });
 
 // Run tests on projects. 9-11 are for testing fullpath file resolution


### PR DESCRIPTION
Closes #36 (with the easy fix)