### PR TITLE
fix: ensure a slash after the prefix

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -200,6 +200,7 @@ export function replaceTscAliasPaths(
       const modulePath =
         orig.substring(0, index) +
         relativeAliasPath +
+        '/' +
         orig.substring(index + alias.prefix.length);
 
       return modulePath.replace(/\/\//g, '/');


### PR DESCRIPTION
As stated in #39, the current implementation doesn't support a tsconfig like this:
```json
{
  "compilerOptions": {
    "baseUrl": ".",
    "paths": {
      "#*": [
        "src/*"
      ]
    },
  }
}
```

This PR will fix the problem and close #39.