### PR TITLE
Make path replacement more consistent with typescript's behaviour

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -78,7 +78,7 @@ export function replaceTscAliasPaths(
   const aliases = Object.keys(paths)
     .map((alias) => {
       const _paths = paths[alias as keyof typeof paths].map((path) => {
-        path = path.replace(/\*$/, '').replace('.t', '.j');
+        path = path.replace(/\*$/, '').replace(/\.ts(x)?$/, '.js$1');
         if (isAbsolute(path)) {
           path = relative(configDir, path);
         }


### PR DESCRIPTION
Following #43, here is a small change to make path replacement more consistent with typescript's behaviour

Here I consider 3 common path configs:

1. `"path": ["other"]`
2. `"path*": ["other/*"]`
3. `"path/*": ["other/*"]`

This PR will make the following mappings will happen correctly.

## For `"path": ["other"]`,
    
`require("path")` -> `require("other")`
`require("pathother")` -> `require("pathother")` // NO CHANGE
`require("pathother/another")` -> `require("pathother/another")` // NO CHANGE
`require("path/other")` -> `require("other/other")`
`require("path/other/another")` -> `require("other/other/another")`

## For `"path*": ["other/*"]`
    
`require("path")` -> `require("path")` // NO CHANGE
`require("pathother")` -> `require("other/other")`
`require("pathother/another")` -> `require("other/other/another")`
`require("path/other")` -> `require("other/other")`
`require("path/other/another")` -> `require("other/other/another")`

## For `"path/*": ["other/*"]`
    
`require("path")` -> `require("path")` // NO CHANGE
`require("pathother")` -> `require("pathother")` // NO CHANGE
`require("pathother/another")` -> `require("pathother/another")` // NO CHANGE
`require("path/other")` -> `require("other/other")`
`require("path/other/another")` -> `require("other/other/another")`