### PR TITLE
Added default baseUrl path

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -61,6 +61,9 @@ export async function replaceTscAliasPaths(
   if (options.outDir) {
     outDir = options.outDir;
   }
+  if (!baseUrl) {
+    baseUrl = "./";
+  }
   assert(baseUrl, 'compilerOptions.baseUrl is not set');
   assert(paths, 'compilerOptions.paths is not set');
   assert(outDir, 'compilerOptions.outDir is not set');


### PR DESCRIPTION
Closes #49

- Added default baseUrl path. When no baseUrl is specified, then the program will default to project directory.