### PR TITLE
fix: file not found when file extension is not set in extends option

### DIFF
--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -49,7 +49,7 @@ export const loadConfig = (file: string): ITSConfig => {
   if (ext) {
     return {
       ...(ext.startsWith('.') ?
-        loadConfig(join(dirname(file), ext)) :
+        loadConfig(join(dirname(file), ext.endsWith('.json') ? ext : `${ext}.json`)) :
         loadConfig(resolveTsConfigExtendsPath(ext, file))),
       ...config,
     };


### PR DESCRIPTION
Thanks for your library, it saved me a lot of time!
There is a problem of `extends` option's analyzation. 
As described in [TypeScript's official document](https://www.typescriptlang.org/tsconfig#extends), we usually `don't` add extension `.json` in extends option, like following:

```json
{
  "extends": "./configs/base",
  "files": ["main.ts", "supplemental.ts"]
}
```

This will cause `loadConfig` fail and throwing **file not found error** here: https://github.com/justkey007/tsc-alias/blob/master/src/helpers/index.ts#L32

Would please consider to automatically add `.json` when it's not been set? It's really a common case IMO.