### PR TITLE
Add support for configuring `resolveFullPaths` and `verbose` via `tsconfig.json`, deprecate `--silent` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,12 @@ Here are all the available options:
     </tr>
     <tr>
       <td>silent</td>
-      <td>Reduced terminal output</td>
+      <td>Reduced terminal output. This is a deprecated option and no longer has any effect.</td>
+      <td><code>true</code></td>
+    </tr>
+    <tr>
+      <td>verbose</td>
+      <td>Additional information is output to the terminal</td>
       <td><code>false</code></td>
     </tr>
     <tr>
@@ -105,3 +110,26 @@ Here are all the available options:
     </tr>
   </tbody>
 </table>
+
+### Configuration via `tsconfig.json` Example
+```json
+{
+  "compilerOptions": {
+    ...
+  },
+  "tsc-alias": {
+    "verbose": false,
+    "resolveFullPaths": true,
+    "replacers": {
+      "exampleReplacer": {
+        "enabled": true,
+        "file": "./exampleReplacer.js"
+      },
+      "otherReplacer": {
+        "enabled": true,
+        "file": "./otherReplacer.js"
+      }
+    }
+  }
+}
+```

--- a/projects/project18/package.json
+++ b/projects/project18/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "project18",
+  "type": "module",
+  "scripts": {
+    "build": "tsc && tsc-alias",
+    "start": "npm run build && node ./dist/src/index.js"
+  }
+}

--- a/projects/project18/src/index.ts
+++ b/projects/project18/src/index.ts
@@ -1,0 +1,2 @@
+import * as tests from './utils';
+console.log(tests);

--- a/projects/project18/src/utils/authorization/index.ts
+++ b/projects/project18/src/utils/authorization/index.ts
@@ -1,0 +1,2 @@
+const a = 'testa';
+export { a };

--- a/projects/project18/src/utils/get-spec.ts
+++ b/projects/project18/src/utils/get-spec.ts
@@ -1,0 +1,2 @@
+const c = 'testc';
+export { c };

--- a/projects/project18/src/utils/index.ts
+++ b/projects/project18/src/utils/index.ts
@@ -1,0 +1,5 @@
+export * from './authorization';
+export * from './get-spec';
+export * from './regex';
+export * from './test-helpers';
+export * from './validation';

--- a/projects/project18/src/utils/regex.ts
+++ b/projects/project18/src/utils/regex.ts
@@ -1,0 +1,2 @@
+const d = 'testd';
+export { d };

--- a/projects/project18/src/utils/test-helpers/index.ts
+++ b/projects/project18/src/utils/test-helpers/index.ts
@@ -1,0 +1,2 @@
+const b = 'testb';
+export { b };

--- a/projects/project18/src/utils/validation.ts
+++ b/projects/project18/src/utils/validation.ts
@@ -1,0 +1,2 @@
+const e = 'teste';
+export { e };

--- a/projects/project18/tsconfig.json
+++ b/projects/project18/tsconfig.json
@@ -1,0 +1,34 @@
+{
+    "compilerOptions": {
+        "target": "es2020",
+        "module": "es2020",
+        "outDir": "./dist",
+        "rootDir": ".",
+        "baseUrl": ".",
+        "paths": {
+            "@container": [
+                "src/container.ts"
+            ],
+            "@interfaces": [
+                "src/interfaces.ts"
+            ],
+            "@main": [
+                "src/main.ts"
+            ],
+            "@util": [
+                "src/utils/index.ts"
+            ]
+        },
+        "moduleResolution": "node"
+    },
+    "include": [
+        "src/**/*.ts",
+        "test/**/*.ts"
+    ],
+    "exclude": [
+        "node_modules"
+    ],
+    "tsc-alias": {
+        "resolveFullPaths": true
+    }
+}

--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -17,7 +17,10 @@ program
     '-f, --resolve-full-paths',
     'Attempt to fully resolve import paths if the corresponding .js file can be found'
   )
-  .option('-s, --silent', 'Reduced terminal output (default) [deprecated]')
+  .option(
+    '-s, --silent',
+    'Reduced terminal output (default: true) [deprecated]'
+  )
   .option('-v, --verbose', 'Additional information is output to the terminal')
   .option('-r, --replacer <replacers...>', 'path to optional extra replacer')
   .parseAsync(process.argv);

--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -17,7 +17,8 @@ program
     '-f, --resolve-full-paths',
     'Attempt to fully resolve import paths if the corresponding .js file can be found'
   )
-  .option('-s, --silent', 'reduced terminal output')
+  .option('-s, --silent', 'Reduced terminal output (default) [deprecated]')
+  .option('-v, --verbose', 'Additional information is output to the terminal')
   .option('-r, --replacer <replacers...>', 'path to optional extra replacer')
   .parseAsync(process.argv);
 
@@ -27,7 +28,7 @@ replaceTscAliasPaths({
   configFile: options.project,
   watch: !!options.watch,
   outDir: options.directory,
-  silent: !!options.silent,
+  verbose: !!options.verbose,
   resolveFullPaths: !!options.resolveFullPaths,
   replacers: options.replacer
 });

--- a/src/helpers/config.ts
+++ b/src/helpers/config.ts
@@ -41,6 +41,10 @@ export const loadConfig = (file: string): ITSConfig => {
     };
   }
 
+  console.log('--------------------');
+  console.dir(config, { depth: 10 });
+  console.log('--------------------');
+
   return config;
 };
 

--- a/src/helpers/config.ts
+++ b/src/helpers/config.ts
@@ -6,9 +6,9 @@ import { IRawTSConfig, ITSConfig } from '../interfaces';
 
 export const loadConfig = (file: string): ITSConfig => {
   if (!fs.existsSync(file)) {
-    console.log(
+    console.error(
       //[BgRed] Error: [Reset] [FgRed_]File ${file} not found[Reset]
-      `\x1b[41m Error: \x1b[0m \x1b[31mFile ${file} not found\x1b[0m`
+      `\x1b[41mtsc-alias error:\x1b[0m \x1b[31mFile ${file} not found\x1b[0m\n`
     );
     process.exit();
   }
@@ -20,7 +20,7 @@ export const loadConfig = (file: string): ITSConfig => {
       declarationDir: undefined,
       paths: undefined
     },
-    'tsc-alias': TSCReplacers
+    'tsc-alias': TSCAliasConfig
   } = Json.loadS<IRawTSConfig>(file, true);
 
   const config: ITSConfig = {};
@@ -28,7 +28,10 @@ export const loadConfig = (file: string): ITSConfig => {
   if (outDir) config.outDir = outDir;
   if (paths) config.paths = paths;
   if (declarationDir) config.declarationDir = declarationDir;
-  if (TSCReplacers?.replacers) config.replacers = TSCReplacers.replacers;
+  if (TSCAliasConfig?.replacers) config.replacers = TSCAliasConfig.replacers;
+  if (TSCAliasConfig?.resolveFullPaths)
+    config.resolveFullPaths = TSCAliasConfig.resolveFullPaths;
+  if (TSCAliasConfig?.verbose) config.verbose = TSCAliasConfig.verbose;
 
   if (ext) {
     return {
@@ -40,10 +43,6 @@ export const loadConfig = (file: string): ITSConfig => {
       ...config
     };
   }
-
-  console.log('--------------------');
-  console.dir(config, { depth: 10 });
-  console.log('--------------------');
 
   return config;
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,12 +36,12 @@ export { ReplaceTscAliasPathsOptions, AliasReplacer };
 export async function replaceTscAliasPaths(
   options: ReplaceTscAliasPathsOptions = {
     watch: false,
-    silent: false,
+    verbose: false,
     declarationDir: undefined,
     output: undefined
   }
 ) {
-  const output = options.output ?? new Output(options.silent);
+  const output = options.output ?? new Output(options.verbose);
 
   const configFile = !options.configFile
     ? resolve(process.cwd(), 'tsconfig.json')

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,8 +56,17 @@ export async function replaceTscAliasPaths(
     outDir,
     declarationDir,
     paths,
-    replacers
+    replacers,
+    resolveFullPaths,
+    verbose
   } = loadConfig(configFile);
+
+  output.setVerbose(verbose);
+
+  if (options.resolveFullPaths || resolveFullPaths) {
+    options.resolveFullPaths = true;
+  }
+
   const _outDir = options.outDir ?? outDir;
   if (declarationDir && _outDir !== declarationDir) {
     options.declarationDir ??= declarationDir;
@@ -178,6 +187,7 @@ export async function replaceTscAliasPaths(
 
   output.info(`${replaceCount} files were affected!`);
   if (options.watch) {
+    output.setVerbose(true);
     output.info('[Watching for file changes...]');
     const filesWatcher = watch(globPattern);
     const tsconfigWatcher = watch(config.configFile);

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -5,6 +5,8 @@ export interface IRawTSConfig {
   compilerOptions?: ITSConfig;
   'tsc-alias': {
     replacers?: ReplacerOptions;
+    resolveFullPaths?: boolean;
+    verbose?: boolean;
   };
 }
 
@@ -20,6 +22,8 @@ export interface ITSConfig {
   declarationDir?: string;
   paths?: PathLike;
   replacers?: ReplacerOptions;
+  resolveFullPaths?: boolean;
+  verbose?: boolean;
 }
 
 export interface IConfig {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -43,7 +43,7 @@ export interface ReplaceTscAliasPathsOptions {
   outDir?: string;
   declarationDir?: string;
   watch?: boolean;
-  silent?: boolean;
+  verbose?: boolean;
   resolveFullPaths?: boolean;
   replacers?: string[];
   output?: Output;

--- a/src/utils/output.ts
+++ b/src/utils/output.ts
@@ -12,7 +12,9 @@ export class Output {
 
   error(message: string, exitProcess = false) {
     //           [BgRed_] Error: [Reset] [FgRed_]${message}[Reset][LF]
-    console.log(`\x1b[41mtsc-alias error:\x1b[0m \x1b[31m${message}\x1b[0m\n`);
+    console.error(
+      `\x1b[41mtsc-alias error:\x1b[0m \x1b[31m${message}\x1b[0m\n`
+    );
 
     if (exitProcess) process.exit(1);
   }

--- a/src/utils/output.ts
+++ b/src/utils/output.ts
@@ -1,17 +1,19 @@
 export class Output {
-  constructor(private silent = false) {
-    this.info('=== tsc-alias starting ===');
+  constructor(private verbose = false) {}
+
+  setVerbose(value: boolean) {
+    this.verbose = value;
   }
 
   info(message: string) {
-    if (this.silent) return;
-    console.log(`Info: ${message}`);
+    if (!this.verbose) return;
+    console.log(`tsc-alias info: ${message}`);
   }
 
   error(message: string, exitProcess = false) {
-    if (!this.silent)
-      //           [BgRed_] Error: [Reset] [FgRed_]${message}[Reset][LF]
-      console.log(`\x1b[41m Error: \x1b[0m \x1b[31m${message}\x1b[0m\n`);
+    //           [BgRed_] Error: [Reset] [FgRed_]${message}[Reset][LF]
+    console.log(`\x1b[41mtsc-alias error:\x1b[0m \x1b[31m${message}\x1b[0m\n`);
+
     if (exitProcess) process.exit(1);
   }
 

--- a/tests/test.spec.ts
+++ b/tests/test.spec.ts
@@ -83,8 +83,10 @@ it(`Import regex does not match edge cases from keywords in strings`, function (
 });
 
 // Run tests on projects. 9-11 are for testing fullpath file resolution
-[1, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17].forEach((value) => {
-  it(`Project ${value} runs after alias resolution`, () => {
-    runTestProject(value);
-  });
-});
+[1, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18].forEach(
+  (value) => {
+    it(`Project ${value} runs after alias resolution`, () => {
+      runTestProject(value);
+    });
+  }
+);


### PR DESCRIPTION
Adds the following:
- Add support for configuring `resolveFullPaths` and `verbose` via `tsconfig.json`
- Use `console.error` for printing errors to the terminal
- Add example `tsconfig.json` configuration to README.md
- Add `project18` test for `tsconfig.json` `resolveFullPaths` option
- Add `--verbose` argument defaulting to `false`.
- Deprecate `--silent` argument
- Remove `tsc-alias starting` message from output init
- Prefix output messages with `tsc-alias` to indicate what generated the message
- Remove condition for error output so errors don't cause a silent failure
- Add `output.setVerbose` method to enable controlling verbose setting after the output class is instantiated

This turned in to a slightly larger pull than I expected. I initially set out to add the ability to configure `resolveFullPaths` and `silent` via `tsconfig.json` entries. However after looking at how the output class was created I decided to refactor things a bit and deprecate the `--silent` option instead - opting for a `--verbose` flag instead.

This fits with how I would expect a compilation utility to work:
 - When the application completes with no errors, no output is generated
 - When an error occurs, details for the error are always output

This matches the behavior of the `tsc` command when compiling an application - there is zero output by default unless an error occurs.

With the need for full path resolution for any projects utilizing ESM I thought it would be better to have the `resolveFullPaths` option be a setting that can be set in the `tsconfig.json` - versus adding it to all of the places where `tsc-alias` is executed. I've also added a new test that has this kind of configuration to validate that it works properly.

Finally, I've updated the `README.md` a bit with an example for configuring via `tsconfig.json` as well as details on the `--verbose` flag.

I've tested these changes in my monorepo which is slowly converting libraries / applications over to use ESM and it works great so far. Please let me know if there are any changes needed or concerns with anything in this pull request. Thank you!