### PR TITLE
feat: Support for single file sync processing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,8 @@ typings/
 
 # Compiled source
 dist
+dist-base
+dist-tsc-alias
 temp
 # Optional eslint cache
 .eslintcache
@@ -86,3 +88,7 @@ temp
 package-lock.json
 
 types
+
+# Editor
+.idea
+.history

--- a/README.md
+++ b/README.md
@@ -133,3 +133,21 @@ Here are all the available options:
   }
 }
 ```
+
+### SingleFileReplacer
+
+We can use tsc-alias in a single file, with a function that returns the modified contents.
+
+We prepare the replacer with `prepareSingleFileReplaceTscAliasPaths()`, passing the same options that we would pass to `replaceTscAliasPaths()`. That will return a promise of a function that receives the file contents and path, and returns the transformed contents, synchronously.
+
+```typescript
+import { prepareSingleFileReplaceTscAliasPaths } from 'tsc-alias';
+
+const runFile: SingleFileReplacer = await prepareSingleFileReplaceTscAliasPaths(options?);
+
+function treatFile(filePath: string) {
+  const fileContents = fs.readFileSync(filePath, 'utf8');
+  const newContents = runFile({fileContents, filePath});
+  // do stuff with newContents
+}
+```

--- a/projects/project19/package.json
+++ b/projects/project19/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "project19",
+  "type": "module",
+  "scripts": {
+    "build": "tsc && tsc-alias",
+    "build:tsc-base": "tsc --outDir dist-base",
+    "start": "npm run build && node ./dist/src/index.js"
+  }
+}

--- a/projects/project19/src/index.ts
+++ b/projects/project19/src/index.ts
@@ -1,0 +1,2 @@
+import * as tests from './utils';
+console.log(tests);

--- a/projects/project19/src/utils/authorization/index.ts
+++ b/projects/project19/src/utils/authorization/index.ts
@@ -1,0 +1,2 @@
+const a = 'testa';
+export { a };

--- a/projects/project19/src/utils/get-spec.ts
+++ b/projects/project19/src/utils/get-spec.ts
@@ -1,0 +1,2 @@
+const c = 'testc';
+export { c };

--- a/projects/project19/src/utils/index.ts
+++ b/projects/project19/src/utils/index.ts
@@ -1,0 +1,5 @@
+export * from './authorization';
+export * from './get-spec';
+export * from './regex';
+export * from './test-helpers';
+export * from './validation';

--- a/projects/project19/src/utils/regex.ts
+++ b/projects/project19/src/utils/regex.ts
@@ -1,0 +1,2 @@
+const d = 'testd';
+export { d };

--- a/projects/project19/src/utils/test-helpers/index.ts
+++ b/projects/project19/src/utils/test-helpers/index.ts
@@ -1,0 +1,2 @@
+const b = 'testb';
+export { b };

--- a/projects/project19/src/utils/validation.ts
+++ b/projects/project19/src/utils/validation.ts
@@ -1,0 +1,2 @@
+const e = 'teste';
+export { e };

--- a/projects/project19/tsconfig.json
+++ b/projects/project19/tsconfig.json
@@ -1,0 +1,34 @@
+{
+    "compilerOptions": {
+        "target": "es2020",
+        "module": "es2020",
+        "outDir": "./dist",
+        "rootDir": ".",
+        "baseUrl": ".",
+        "paths": {
+            "@container": [
+                "src/container.ts"
+            ],
+            "@interfaces": [
+                "src/interfaces.ts"
+            ],
+            "@main": [
+                "src/main.ts"
+            ],
+            "@util": [
+                "src/utils/index.ts"
+            ]
+        },
+        "moduleResolution": "node"
+    },
+    "include": [
+        "src/**/*.ts",
+        "test/**/*.ts"
+    ],
+    "exclude": [
+        "node_modules"
+    ],
+    "tsc-alias": {
+        "resolveFullPaths": true
+    }
+}

--- a/src/helpers/config-preparer.ts
+++ b/src/helpers/config-preparer.ts
@@ -1,0 +1,82 @@
+import * as normalizePath from 'normalize-path';
+import {
+  IConfig,
+  IProjectConfig,
+  ReplaceTscAliasPathsOptions
+} from '../interfaces';
+import { Output, PathCache, TrieNode } from '../utils';
+import { basename, dirname, isAbsolute, normalize, resolve } from 'path';
+import { existsSync } from 'fs';
+import { loadConfig } from './config';
+import { importReplacers } from './replacers';
+
+export async function prepareConfig(
+  options: ReplaceTscAliasPathsOptions = {
+    watch: false,
+    verbose: false,
+    declarationDir: undefined,
+    output: undefined,
+    aliasTrie: undefined
+  }
+) {
+  const output = options.output ?? new Output(options.verbose);
+
+  const configFile = !options.configFile
+    ? resolve(process.cwd(), 'tsconfig.json')
+    : !isAbsolute(options.configFile)
+    ? resolve(process.cwd(), options.configFile)
+    : options.configFile;
+
+  output.assert(existsSync(configFile), `Invalid file path => ${configFile}`);
+
+  const {
+    baseUrl = './',
+    outDir,
+    declarationDir,
+    paths,
+    replacers,
+    resolveFullPaths,
+    verbose
+  } = loadConfig(configFile);
+
+  output.setVerbose(verbose);
+
+  if (options.resolveFullPaths || resolveFullPaths) {
+    options.resolveFullPaths = true;
+  }
+
+  const _outDir = options.outDir ?? outDir;
+  if (declarationDir && _outDir !== declarationDir) {
+    options.declarationDir ??= declarationDir;
+  }
+
+  output.assert(_outDir, 'compilerOptions.outDir is not set');
+
+  const configDir: string = normalizePath(dirname(configFile));
+
+  // config with project details and paths
+  const projectConfig: IProjectConfig = {
+    configFile: configFile,
+    baseUrl: baseUrl,
+    outDir: _outDir,
+    configDir: configDir,
+    outPath: normalizePath(normalize(configDir + '/' + _outDir)),
+    confDirParentFolderName: basename(configDir),
+    hasExtraModule: false,
+    configDirInOutPath: null,
+    relConfDirPathInOutPath: null,
+    pathCache: new PathCache(!options.watch)
+  };
+
+  const config: IConfig = {
+    ...projectConfig,
+    output: output,
+    aliasTrie:
+      options.aliasTrie ?? TrieNode.buildAliasTrie(projectConfig, paths),
+    replacers: []
+  };
+
+  // Import replacers.
+  await importReplacers(config, replacers, options.replacers);
+  return config;
+}

--- a/src/helpers/replacers.ts
+++ b/src/helpers/replacers.ts
@@ -79,6 +79,7 @@ export async function importReplacers(
 
 /**
  * replaceAlias replaces aliases in file.
+ * @param config configuration
  * @param file file to replace aliases in.
  * @param resolveFullPath if tsc-alias should resolve the full path
  * @returns if something has been replaced.
@@ -89,6 +90,29 @@ export async function replaceAlias(
   resolveFullPath?: boolean
 ): Promise<boolean> {
   const code = await fsp.readFile(file, 'utf8');
+  const tempCode = replaceAliasString(config, file, code, resolveFullPath);
+
+  if (code !== tempCode) {
+    await fsp.writeFile(file, tempCode, 'utf8');
+    return true;
+  }
+  return false;
+}
+
+/**
+ * replaceAliasString  replaces aliases in the given code content and returns the changed code.
+ * @param config configuration
+ * @param file path of the file to replace aliases in.
+ * @param code contents of the file to replace aliases in.
+ * @param resolveFullPath if tsc-alias should resolve the full path
+ * @returns content of the file with any replacements possible applied.
+ */
+export function replaceAliasString(
+  config: IConfig,
+  file: string,
+  code: string,
+  resolveFullPath?: boolean
+): string {
   let tempCode = code;
 
   config.replacers.forEach((replacer) => {
@@ -107,9 +131,5 @@ export async function replaceAlias(
     tempCode = resolveFullImportPaths(tempCode, file);
   }
 
-  if (code !== tempCode) {
-    await fsp.writeFile(file, tempCode, 'utf8');
-    return true;
-  }
-  return false;
+  return tempCode;
 }

--- a/tests/test.spec.ts
+++ b/tests/test.spec.ts
@@ -120,7 +120,6 @@ it('prepareSingleFileReplaceTscAliasPaths() works', async () => {
     configFile: join(projectDir, 'tsconfig.json'),
     resolveFullPaths: true
   };
-  const config = await prepareConfig(options);
 
   const runFile = await prepareSingleFileReplaceTscAliasPaths(options);
 

--- a/tests/test.spec.ts
+++ b/tests/test.spec.ts
@@ -134,7 +134,6 @@ it('prepareSingleFileReplaceTscAliasPaths() works', async () => {
     onlyFiles: true
   });
 
-
   expect(files.length).toBeGreaterThan(0);
 
   files.map((filePath) => {

--- a/tests/test.spec.ts
+++ b/tests/test.spec.ts
@@ -134,9 +134,6 @@ it('prepareSingleFileReplaceTscAliasPaths() works', async () => {
     onlyFiles: true
   });
 
-  console.log(
-    JSON.stringify({ files, outPath, basePath, options, config }, null, 2)
-  );
 
   expect(files.length).toBeGreaterThan(0);
 


### PR DESCRIPTION
- adding `prepareSingleFileReplaceTscAliasPaths(options?)`, which will return a promise of the singleFileReplacer function, with the config already prepared.
- `SingleFileReplacer` is a function that will receive `{fileContents: string, filePath: string}` and return the treated contents

fix #84