### PR TITLE
fix: syntax bug

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -86,9 +86,9 @@ export interface ReplacerOptions {
 
 export interface IOutput {
   /**
-   * verbose setter sets if the output should act verbose.
+   * verbose value sets if the output should act verbose.
    */
-  set verbose(value: boolean);
+  verbose: boolean;
   /**
    * info logs a message on the info level.
    * @param {string} message message to log.


### PR DESCRIPTION
Small syntax bug in IOutput interface. Typescript gives error TS1131 because set is unknown.