### PR TITLE
Fixed trailing slash

### DIFF
--- a/projects/project16/package.json
+++ b/projects/project16/package.json
@@ -2,6 +2,6 @@
   "name": "project16",
   "scripts": {
     "build": "tsc && tsc-alias -r replacer.js",
-    "start": "npm run build && node ./dist/index.js"
+    "start": "npm run build && node ./dist/server/index.js"
   }
 }

--- a/projects/project16/tsconfig.json
+++ b/projects/project16/tsconfig.json
@@ -6,7 +6,7 @@
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
-    "outDir": "./dist",
+    "outDir": "dist/server/",
     "declarationDir": "./types",
     "removeComments": true,
     "importHelpers": false,

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,7 +39,7 @@ export async function replaceTscAliasPaths(
   const output = config.output;
 
   // Finding files and changing alias paths
-  const posixOutput = config.outPath.replace(/\\/g, '/');
+  const posixOutput = config.outPath.replace(/\\/g, '/').replace(/\/+$/g, '');
   const globPattern = [
     `${posixOutput}/**/*.{mjs,cjs,js,jsx,d.{mts,cts,ts,tsx}}`,
     `!${posixOutput}/**/node_modules`


### PR DESCRIPTION
This pr fixes #112
When outDir has a trailing slash like: `./dist/` the globPattern would become `./dist//**`, which leads to no files being found.