### PR TITLE
Fixed readme build scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ npm install --save-dev tsc-alias
 
 "scripts": {
   "build": "tsc && tsc-alias",
-  "build:watch": "tsc -w & tsc-alias -w"
+  "build:watch": "concurrently \"tsc -w\" \"tsc-alias -w\""
 }
 ```
 


### PR DESCRIPTION
fixes #117 
```bash
tsc -w & tsc-alias -w
```
Doesn't seem to work. See #117 
Updated script to:

```bash
concurrently \"tsc -w\" \"tsc-alias -w\"
```

Src: https://github.com/justkey007/tsc-alias/issues/117#issuecomment-1123623945