### PR TITLE
fix(default-replacer): Remove js extension when checking if path is valid

### DIFF
--- a/src/replacers/default.replacer.ts
+++ b/src/replacers/default.replacer.ts
@@ -52,10 +52,10 @@ export default function replaceImportStatement({
             : normalizePath(
                 `${absoluteAliasPath}/${requiredModule.replace(
                   new RegExp(
-                    `^${alias.prefix.replace(
+                    `(?:^${alias.prefix.replace(
                       /[-[\]{}()*+?.,\\^$|#\s]/g,
                       '\\$&'
-                    )}`
+                    )})|(?:\.js$)`, 'g'
                   ),
                   ''
                 )}`


### PR DESCRIPTION
When trying to use module resolution set to nodenext/node12 I am forced to add the compiled extension to all of my imports. This is then reflected in my index.d.ts file as it includes the .js extension. I am bundling all the files into one dist file, so the compiled js file doesn't exist which causes the alias to not be replaced. What does exist is the .d.ts file so removing the .js extension makes the path become valid due to it matching the .d.ts file. 