### PR TITLE
Added debug mode

### DIFF
--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -21,7 +21,8 @@ program
     '-s, --silent',
     'Reduced terminal output (default: true) [deprecated]'
   )
-  .option('-v, --verbose', 'Additional information is output to the terminal')
+  .option('-v, --verbose', 'Additional information is send to the terminal')
+  .option('--debug', 'Debug information is send to the terminal')
   .option('-r, --replacer <replacers...>', 'path to optional extra replacer')
   .parseAsync(process.argv);
 
@@ -32,6 +33,7 @@ replaceTscAliasPaths({
   watch: !!options.watch,
   outDir: options.directory,
   verbose: !!options.verbose,
+  debug: !!options.debug,
   resolveFullPaths: !!options.resolveFullPaths,
   replacers: options.replacer
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,7 @@ export {
 const defaultConfig = {
   watch: false,
   verbose: false,
+  debug: false,
   declarationDir: undefined,
   output: undefined,
   aliasTrie: undefined
@@ -47,10 +48,12 @@ export async function replaceTscAliasPaths(
     `${posixOutput}/**/*.{mjs,cjs,js,jsx,d.{mts,cts,ts,tsx}}`,
     `!${posixOutput}/**/node_modules`
   ];
+  output.debug('Search pattern:', globPattern);
   const files = sync(globPattern, {
     dot: true,
     onlyFiles: true
   });
+  output.debug('Found files:', files);
 
   // Make array with promises for file changes
   // Wait for all promises to resolve

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -51,6 +51,7 @@ export interface ReplaceTscAliasPathsOptions {
   declarationDir?: string;
   watch?: boolean;
   verbose?: boolean;
+  debug?: boolean;
   resolveFullPaths?: boolean;
   replacers?: string[];
   output?: IOutput;
@@ -89,6 +90,11 @@ export interface IOutput {
    * verbose value sets if the output should act verbose.
    */
   verbose: boolean;
+  /**
+   * debug logs a message on the debug level.
+   * @param {string} message message to log.
+   */
+  debug: (message: string, obj?: unknown) => void;
   /**
    * info logs a message on the info level.
    * @param {string} message message to log.

--- a/src/replacers/base-url.replacer.ts
+++ b/src/replacers/base-url.replacer.ts
@@ -17,6 +17,7 @@ export default function replaceBaseUrlImport({
   config
 }: AliasReplacerArguments): string {
   const requiredModule = orig.match(newStringRegex())?.groups?.path;
+  config.output.debug('base-url replacer - requiredModule: ', requiredModule);
   config.output.assert(
     typeof requiredModule == 'string',
     `Unexpected import statement pattern ${orig}`
@@ -24,6 +25,7 @@ export default function replaceBaseUrlImport({
 
   // Check if import is already resolved.
   if (requiredModule.startsWith('.')) {
+    config.output.debug('base-url replacer - already resolved');
     return orig;
   }
 
@@ -40,12 +42,18 @@ export default function replaceBaseUrlImport({
     if (!relativePath.startsWith('.')) {
       relativePath = './' + relativePath;
     }
+    config.output.debug('base-url replacer - relativePath: ', relativePath);
 
     const index = orig.indexOf(requiredModule);
     const newImportScript =
       orig.substring(0, index) + relativePath + '/' + orig.substring(index);
+    config.output.debug(
+      'base-url replacer - newImportScript: ',
+      newImportScript
+    );
 
     const modulePath = newImportScript.match(newStringRegex()).groups.path;
+    config.output.debug('base-url replacer - modulePath: ', modulePath);
     return newImportScript.replace(modulePath, normalizePath(modulePath));
   }
   return orig;

--- a/src/replacers/default.replacer.ts
+++ b/src/replacers/default.replacer.ts
@@ -32,12 +32,14 @@ export default function replaceImportStatement({
   config
 }: AliasReplacerArguments) {
   const requiredModule = orig.match(newStringRegex())?.groups?.path;
+  config.output.debug('default replacer - requiredModule: ', requiredModule);
   config.output.assert(
     typeof requiredModule == 'string',
     `Unexpected import statement pattern ${orig}`
   );
   // Lookup which alias should be used for this given requiredModule.
   const alias = config.aliasTrie.search(requiredModule);
+  config.output.debug('default replacer - alias: ', alias);
   // If an alias isn't found the original.
   if (!alias) return orig;
 
@@ -58,6 +60,10 @@ export default function replaceImportStatement({
         alias.paths[i].basePath,
         alias.paths[i].path
       );
+      config.output.debug(
+        'default replacer - absoluteAliasPath: ',
+        absoluteAliasPath
+      );
 
       // Check if path is valid.
       if (
@@ -72,6 +78,7 @@ export default function replaceImportStatement({
               )
         )
       ) {
+        config.output.debug('default replacer - Invalid path');
         continue;
       }
 
@@ -82,6 +89,10 @@ export default function replaceImportStatement({
       if (!relativeAliasPath.startsWith('.')) {
         relativeAliasPath = './' + relativeAliasPath;
       }
+      config.output.debug(
+        'default replacer - relativeAliasPath: ',
+        relativeAliasPath
+      );
 
       const index = orig.indexOf(alias.prefix);
       const newImportScript =
@@ -89,8 +100,13 @@ export default function replaceImportStatement({
         relativeAliasPath +
         '/' +
         orig.substring(index + alias.prefix.length);
+      config.output.debug(
+        'default replacer - newImportScript: ',
+        newImportScript
+      );
 
       const modulePath = newImportScript.match(newStringRegex()).groups.path;
+      config.output.debug('default replacer - modulePath: ', modulePath);
 
       return newImportScript.replace(modulePath, normalizePath(modulePath));
     }

--- a/src/utils/output.ts
+++ b/src/utils/output.ts
@@ -8,9 +8,30 @@
 
 /** */
 import { IOutput } from '../interfaces';
+import { inspect } from 'util';
 
 export class Output implements IOutput {
-  constructor(private verb = false) {}
+  // Default empty
+  debug = (message: string, obj?: unknown) => {};
+
+  constructor(private verb = false, debugMode = false) {
+    if (debugMode) {
+      // When in debug mode. Add debug function.
+      this.debug = (message: string, obj?: unknown) => {
+        console.debug(
+          `tsc-alias debug: ${message} ${
+            obj
+              ? inspect(obj, {
+                  showHidden: true,
+                  depth: Infinity,
+                  colors: true
+                })
+              : ''
+          }`
+        );
+      };
+    }
+  }
 
   public set verbose(value: boolean) {
     if (value) {


### PR DESCRIPTION
# tl;dr

Debug mode, enabled with `--debug`, logs debug information to the console. This is useful for debugging and troubleshooting. When debug is disabled the debug function is empty to prevent constant checking of debug state.

# Problem

Troubleshooting tsc-alias is difficult when config doesn't load, or files aren't found.

# Solution

Adding a debug mode to debug the configuration. for example, to see what config is loaded, which files are found or why an alias isn't being replaced.

# Performance
## Use of empty default function

An empty default function is used to prevent the program from checking if it should log the debug data. Making the function optional would place this check at every debug point in the code. By making a default empty function and only replacing that in the constructor ensures that the check is only done once.

## Performance impact

All results are an average of 5 test runs. The result is the time the program takes to run in `ms`.
Test were performed with [tsc-alias-benchmark](https://github.com/raouldeheer/tsc-alias-benchmark).
Test specs:

Ryzen 5800X CPU
32GB Ram
500GB Samsung 970 Evo SSD (With only the benchmark on the drive)
Node 16.15.1

### Previous commit (baseline)
Commit [34f0173](https://github.com/justkey007/tsc-alias/commit/34f0173964a46d4317213a03e3aecc65199bd5cd) was used as a baseline for testing.

<details>
  <summary>Benchmark results</summary>

| files\paths | 10 | 20 | 30 | 40 |  50 |  60 |  70 |  80 |  90 | 100 |
|---------|-----|-----|-----|-----|-----|-----|-----|-----|-----|-----|
|    10   | 35  | 29  | 27  | 27  | 27  | 26  | 27  | 27  | 26  | 26  |
|    20   | 53  | 52  | 50  | 49  | 48  | 51  | 49  | 50  | 48  | 52  |
|    30   | 71  | 73  | 72  | 74  | 80  | 75  | 72  | 72  | 72  | 70  |
|    40   | 94  | 94  | 96  | 98  | 98  | 96  | 96  | 96  | 96  | 94  |
|    50   | 119 | 119 | 119 | 117 | 119 | 121 | 120 | 120 | 120 | 119 |
|    60   | 142 | 142 | 141 | 142 | 144 | 144 | 139 | 143 | 143 | 145 |
|    70   | 165 | 167 | 164 | 166 | 165 | 165 | 164 | 167 | 167 | 167 |
|    80   | 187 | 184 | 190 | 191 | 186 | 187 | 188 | 194 | 189 | 191 |
|    90   | 211 | 208 | 208 | 211 | 215 | 211 | 212 | 207 | 211 | 214 |
|   100   | 230 | 231 | 235 | 235 | 235 | 235 | 233 | 236 | 241 | 241 |
|   110   | 260 | 260 | 261 | 256 | 257 | 265 | 260 | 262 | 257 | 259 |
|   120   | 280 | 285 | 280 | 279 | 282 | 277 | 283 | 287 | 284 | 279 |
|   130   | 301 | 305 | 308 | 304 | 303 | 309 | 301 | 308 | 309 | 305 |
|   140   | 323 | 328 | 330 | 329 | 327 | 330 | 325 | 330 | 332 | 328 |
|   150   | 348 | 353 | 354 | 348 | 354 | 348 | 354 | 356 | 352 | 348 |
|   160   | 376 | 371 | 372 | 376 | 371 | 379 | 382 | 376 | 378 | 381 |
|   170   | 398 | 398 | 397 | 400 | 399 | 394 | 398 | 402 | 401 | 402 |
|   180   | 419 | 427 | 418 | 416 | 424 | 425 | 424 | 421 | 418 | 428 |
|   190   | 441 | 444 | 444 | 450 | 450 | 444 | 467 | 443 | 443 | 442 |
|   200   | 464 | 470 | 470 | 471 | 468 | 471 | 472 | 480 | 483 | 483 |

</details>

### Impact with debug mode turned off (default)
There is no measurable performance impact compared to the previous commit. Results stay within 1% of the baseline.

<details>
  <summary>Benchmark results</summary>

| files\paths | 10 | 20 | 30 | 40 |  50 |  60 |  70 |  80 |  90 | 100 |
|---------|-----|-----|-----|-----|-----|-----|-----|-----|-----|-----|
|    10   | 33  | 30  | 28  | 27  | 28  | 26  | 26  | 26  | 26  | 27  |
|    20   | 55  | 48  | 49  | 49  | 49  | 54  | 52  | 52  | 54  | 51  |
|    30   | 73  | 73  | 72  | 76  | 80  | 77  | 76  | 78  | 80  | 75  |
|    40   | 98  | 101 | 99  | 99  | 99  | 97  | 97  | 98  | 100 | 99  |
|    50   | 122 | 121 | 121 | 124 | 123 | 124 | 122 | 121 | 122 | 124 |
|    60   | 150 | 147 | 149 | 149 | 149 | 148 | 147 | 151 | 153 | 153 |
|    70   | 172 | 171 | 174 | 177 | 205 | 184 | 204 | 180 | 184 | 177 |
|    80   | 210 | 196 | 201 | 213 | 208 | 208 | 206 | 212 | 202 | 213 |
|    90   | 227 | 239 | 260 | 268 | 224 | 229 | 230 | 234 | 222 | 222 |
|   100   | 248 | 242 | 245 | 246 | 246 | 246 | 244 | 249 | 242 | 244 |
|   110   | 277 | 264 | 268 | 271 | 275 | 274 | 268 | 270 | 275 | 283 |
|   120   | 289 | 301 | 293 | 291 | 297 | 293 | 293 | 292 | 296 | 299 |
|   130   | 313 | 320 | 318 | 318 | 315 | 322 | 325 | 322 | 319 | 316 |
|   140   | 342 | 340 | 346 | 343 | 343 | 345 | 342 | 346 | 347 | 352 |
|   150   | 366 | 366 | 368 | 370 | 362 | 375 | 365 | 370 | 370 | 368 |
|   160   | 400 | 390 | 394 | 393 | 393 | 398 | 396 | 389 | 397 | 397 |
|   170   | 411 | 418 | 419 | 409 | 429 | 420 | 420 | 423 | 423 | 418 |
|   180   | 438 | 438 | 438 | 437 | 443 | 442 | 445 | 438 | 449 | 440 |
|   190   | 471 | 465 | 470 | 466 | 463 | 470 | 467 | 471 | 464 | 470 |
|   200   | 484 | 489 | 483 | 488 | 494 | 490 | 494 | 490 | 492 | 492 |

</details>

### Impact with debug mode turned on
The performance impact is huge, but this is not very important while debugging.

<details>
  <summary>Benchmark results</summary>

| files\paths | 10 |  20  |  30   |  40   |   50  |   60  |   70  |   80  |   90  |  100  |
|---------|-------|-------|-------|-------|-------|-------|-------|-------|-------|-------|
|    10   |  661  |  633  |  660  |  655  |  671  |  693  |  697  |  718  |  730  |  731  |
|    20   | 1198  | 1221  | 1222  | 1246  | 1248  | 1255  | 1285  | 1297  | 1305  | 1313  |
|    30   | 1767  | 1772  | 1799  | 1822  | 1819  | 1838  | 1864  | 1868  | 1874  | 1902  |
|    40   | 2350  | 2364  | 2364  | 2409  | 2397  | 2434  | 2448  | 2443  | 2485  | 2509  |
|    50   | 2966  | 2974  | 3012  | 2989  | 3018  | 3019  | 3000  | 3002  | 3035  | 3044  |
|    60   | 3482  | 3508  | 3536  | 3685  | 3698  | 3692  | 3691  | 3777  | 3763  | 3817  |
|    70   | 4263  | 4330  | 4336  | 4393  | 4496  | 4416  | 4381  | 4391  | 4433  | 4438  |
|    80   | 4918  | 4925  | 4831  | 4870  | 4894  | 4840  | 4849  | 4845  | 4867  | 5020  |
|    90   | 5385  | 5401  | 5416  | 5411  | 5423  | 5517  | 5434  | 5430  | 5543  | 5506  |
|   100   | 5925  | 5932  | 5955  | 5972  | 6128  | 6249  | 6263  | 6232  | 6242  | 6247  |
|   110   | 6729  | 6759  | 6759  | 6979  | 6820  | 6715  | 6717  | 6580  | 6542  | 6560  |
|   120   | 7014  | 7018  | 7036  | 7052  | 7073  | 7091  | 7095  | 7105  | 7114  | 7144  |
|   130   | 7568  | 7590  | 7606  | 7634  | 7849  | 7859  | 7874  | 7906  | 7905  | 7955  |
|   140   | 8431  | 8411  | 8414  | 8543  | 8326  | 8246  | 8244  | 8253  | 8475  | 8790  |
|   150   | 9097  | 9091  | 9129  | 9124  | 9186  | 9301  | 9198  | 9170  | 9484  | 9416  |
|   160   | 9884  | 9880  | 9931  | 9937  | 10149 | 9813  | 9681  | 9523  | 9521  | 9525  |
|   170   | 9978  | 9980  | 10019 | 10017 | 10031 | 10062 | 10079 | 10074 | 10184 | 10461 |
|   180   | 10946 | 10914 | 10979 | 10957 | 10967 | 11582 | 10927 | 10774 | 10825 | 10792 |
|   190   | 11208 | 11222 | 11272 | 11253 | 11286 | 11288 | 11226 | 11123 | 11244 | 11277 |
|   200   | 11713 | 11700 | 11721 | 11756 | 11636 | 11483 | 11469 | 11480 | 11506 | 11516 |

</details>
