### PR TITLE
fix(default-replacer): `(?:\.(js|json)$)` should be replaced by `(?:\\.(js|json)$)`

### DIFF
--- a/projects/project22/package.json
+++ b/projects/project22/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "project22",
+  "private": true,
+  "scripts": {
+    "build": "tsc && tsc-alias",
+    "start": "npm run build && node ./dist/index.js"
+  }
+}

--- a/projects/project22/src/custom_modules/find-json.ts
+++ b/projects/project22/src/custom_modules/find-json.ts
@@ -1,0 +1,1 @@
+export const FINDER = 'finder';

--- a/projects/project22/src/data.json
+++ b/projects/project22/src/data.json
@@ -1,0 +1,3 @@
+{
+  "project": "tsc-alias"
+}

--- a/projects/project22/src/index.ts
+++ b/projects/project22/src/index.ts
@@ -1,0 +1,5 @@
+import { FINDER } from 'custom/find-json';
+import * as data from 'myproject/data.json';
+
+console.log(FINDER);
+console.log(data);

--- a/projects/project22/tsconfig.json
+++ b/projects/project22/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "outDir": "dist",
+    "target": "es5",
+    "module": "commonjs",
+    "strictNullChecks": false,
+    "noImplicitAny": false,
+    "baseUrl": "./src",
+    "resolveJsonModule": true,
+    "paths": {
+      "myproject/*": ["./*"],
+      "custom/*": ["custom_modules/*"]
+    }
+  },
+  "exclude": ["node_modules"]
+}

--- a/src/replacers/default.replacer.ts
+++ b/src/replacers/default.replacer.ts
@@ -17,7 +17,7 @@ function escapeSpecialChars(str: string) {
 
 function getAliasPrefixRegExp(alias: Alias) {
   return new RegExp(
-    `(?:^${escapeSpecialChars(alias.prefix)})|(?:\.(js|json)$)`,
+    `(?:^${escapeSpecialChars(alias.prefix)})|(?:\\.(js|json)$)`,
     'g'
   );
 }

--- a/tests/test.spec.ts
+++ b/tests/test.spec.ts
@@ -89,13 +89,13 @@ it(`Import regex does not match edge cases from keywords in strings`, function (
 });
 
 // Run tests on projects. 9-11 are for testing fullpath file resolution
-[1, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 20, 21].forEach(
-  (value) => {
-    it(`Project ${value} runs after alias resolution`, () => {
-      runTestProject(value);
-    });
-  }
-);
+[
+  1, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 20, 21, 22
+].forEach((value) => {
+  it(`Project ${value} runs after alias resolution`, () => {
+    runTestProject(value);
+  });
+});
 
 it('prepareSingleFileReplaceTscAliasPaths() works', async () => {
   const projectDir = join(projectsRoot, `project19`);


### PR DESCRIPTION
This PR solves the following problem.
```javascript
console.log(`(?:\.(js|json)$)`); // results (?:.(js|json)$).
```
- This expression would match "{any character}js" or "{any character}json" when it is expected to match ".js" or ".json" .
- If the file name ends with "-json.js", the import will fail as in the attached test project22.
