### PR TITLE
Bug index full path resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,11 @@ Here are all the available options:
       <td><code>false</code></td>
     </tr>
     <tr>
+      <td>debug</td>
+      <td>Debug information is send to the terminal</td>
+      <td><code>false</code></td>
+    </tr>
+    <tr>
       <td>replacers</td>
       <td>Files to import as extra replacers <a href="https://github.com/justkey007/tsc-alias/discussions/73">More info</a></td>
       <td><code>[]</code></td>

--- a/projects/project9/package.json
+++ b/projects/project9/package.json
@@ -5,6 +5,6 @@
     "start": "npm run build && node ./dist/index.js"
   },
   "dependencies": {
-    "@esfx/collections-hashmap": "^1.0.0-pre.17"
+    "buffercursor.ts": "1.0.3"
   }
 }

--- a/projects/project9/src/index.ts
+++ b/projects/project9/src/index.ts
@@ -1,7 +1,7 @@
-import { HashMap } from '@esfx/collections-hashmap';
-import { HashMap as HashMap1 } from '@hashmap';
-import { HashMap as HashMap2 } from '@hashmap2';
+import { BufferCursor } from 'buffercursor.ts';
+import { BufferCursor as BufferCursor1 } from '@cursor';
+import { BufferCursor as BufferCursor2 } from '@cursor2';
 
-const map = new HashMap();
-const map1 = new HashMap1();
-const map2 = new HashMap2();
+const map = new BufferCursor(Buffer.alloc(0));
+const map1 = new BufferCursor1(Buffer.alloc(0));
+const map2 = new BufferCursor2(Buffer.alloc(0));

--- a/projects/project9/tsconfig.json
+++ b/projects/project9/tsconfig.json
@@ -4,8 +4,8 @@
     "baseUrl": "./",
     "paths": {
       "@/*": ["./*"],
-      "@hashmap": ["node_modules/@esfx/collections-hashmap/dist/index"],
-      "@hashmap2": ["./node_modules/@esfx/collections-hashmap/dist/index"]
+      "@cursor": ["node_modules/buffercursor.ts/dist/index"],
+      "@cursor2": ["./node_modules/buffercursor.ts/dist/index"]
     }
   }
 }

--- a/src/utils/import-path-resolver.ts
+++ b/src/utils/import-path-resolver.ts
@@ -107,7 +107,7 @@ class ImportPathResolver {
     }
     // Assume the path is a folder; try adding index.js
     let asFilePath = join(importPath, 'index.js');
-    if (importPath.startsWith('./') && !asFilePath.startsWith('./')) {
+    if ((importPath.startsWith('./') || importPath === '.') && !asFilePath.startsWith('./')) {
       asFilePath = './' + asFilePath;
     }
     return existsSync(resolve(this.sourceDir, asFilePath))


### PR DESCRIPTION
This pr should fix #137

# Changes 
 - Added check if import path is equal to `.`
 - Updated readme with debug option

# Tests

Project9 failed because of a change in the dependencies of the dependency that was used to check if resolution to a node_module works. Changed the dependency used by the test to a pinned version of a dependency with no dependencies.
