### PR TITLE
fix: suport import function with  webpackChunkName comment

### DIFF
--- a/src/utils/import-path-resolver.ts
+++ b/src/utils/import-path-resolver.ts
@@ -37,7 +37,7 @@ const importString = `(?:${anyQuote}${pathStringContent}${anyQuote})`;
 // Separate patterns for each style of import statement,
 // wrapped in non-capturing groups,
 // so that they can be strung together in one big pattern.
-const funcStyle = `(?:\\b(?:import|require)\\s*\\(\\s*${importString}\\s*\\))`;
+const funcStyle = `(?:\\b(?:import|require)\\s*\\(\\s*(\\/\\*.*\\*\\/\\s*)?${importString}\\s*\\))`;
 const globalStyle = `(?:\\bimport\\s+${importString})`;
 const fromStyle = `(?:\\bfrom\\s+${importString})`;
 const moduleStyle = `(?:\\bmodule\\s+${importString})`;


### PR DESCRIPTION
support import path with comment，such as:
`await import(/* webpackChunkName: "alias-chunk" */ "@root/test/alias")`