### PR TITLE
fix: replacer got an invalid path if tsconfig.json is out of package dir

### DIFF
--- a/src/utils/trie.ts
+++ b/src/utils/trie.ts
@@ -12,7 +12,7 @@
  */
 
 /** */
-import { isAbsolute, normalize, relative } from 'path';
+import { isAbsolute, normalize, relative, resolve } from 'path';
 import { findBasePathOfAlias, relativeOutPathToConfigDir } from '../helpers';
 import { Alias, IProjectConfig, PathLike } from '../interfaces';
 
@@ -83,7 +83,10 @@ export class TrieNode<T> {
                 .replace(/\*$/, '')
                 .replace(/\.([mc])?ts(x)?$/, '.$1js$2');
               if (isAbsolute(path)) {
-                path = relative(config.configDir, path);
+                path = relative(
+                  resolve(config.configDir, config.baseUrl),
+                  path
+                );
               }
 
               if (


### PR DESCRIPTION
### My problem

I met a problem when use this tool. Here is my `tsconfig.json`:

```json
{
  "compilerOptions": {
      "outDir": "es",
      "baseUrl": ".",
      "paths": {
        "my-list/utils/*": ["/some-absolute-path/example/src/utils/*"]
      }
    },
  "include": ["src/**/*.ts", "src/**/*.tsx"]
}
```

**This `tsconfig.json` is out of my package folder, it is in the `node_module/cache` folder.** When I use `tsc-alias` to transform the alias configured by `tsconfig.json`, I got this exception:

<img width="1124" alt="image" src="https://github.com/justkey007/tsc-alias/assets/29861850/3a4ea7f9-7764-49d6-a6af-f2220f9d4ad1">

### Solution

[This line](https://github.com/justkey007/tsc-alias/blob/master/src/helpers/path.ts#L84) shows that you judge if it's an alias references a file outside the `baseUrl` via `aliasPath.path.includes('..')`.However [this line](https://github.com/justkey007/tsc-alias/blob/master/src/utils/trie.ts#L86) shows that `aliasPath.path` is a path relative to `configDir` (not `baseUrl`). So I changed it to a path relative `baseUrl`.

And I try to run `jest` after my change, but got an error `no tsc-alias command founded`. It seems to be a pnpm problem in my environment:

```
❯ pnpm link -g
 WARN  link:/Users/helium/Desktop/tsc-alias has no binaries
```

So if there is something wrong with Jest result, please notify me. Thanks for your review.