### PR TITLE
feat: custom extension for resolveFullPath and add regex for minified js

### DIFF
--- a/src/helpers/replacers.ts
+++ b/src/helpers/replacers.ts
@@ -128,11 +128,18 @@ export async function importReplacers(
 export async function replaceAlias(
   config: IConfig,
   file: string,
-  resolveFullPath?: boolean
+  resolveFullPath?: boolean,
+  resolveFullExtension?: string
 ): Promise<boolean> {
   config.output.debug('Starting to replace file:', file);
   const code = await fsp.readFile(file, 'utf8');
-  const tempCode = replaceAliasString(config, file, code, resolveFullPath);
+  const tempCode = replaceAliasString(
+    config,
+    file,
+    code,
+    resolveFullPath,
+    resolveFullExtension
+  );
 
   if (code !== tempCode) {
     config.output.debug('replaced file with changes:', file);
@@ -155,7 +162,8 @@ export function replaceAliasString(
   config: IConfig,
   file: string,
   code: string,
-  resolveFullPath?: boolean
+  resolveFullPath?: boolean,
+  resolveFullExtension?: string
 ): string {
   config.replacers.forEach((replacer) => {
     code = replaceSourceImportPaths(code, file, (orig) =>
@@ -170,7 +178,7 @@ export function replaceAliasString(
   // Fully resolve all import paths (not just aliased ones)
   // *after* the aliases are resolved
   if (resolveFullPath) {
-    code = resolveFullImportPaths(code, file);
+    code = resolveFullImportPaths(code, file, resolveFullExtension);
   }
 
   return code;

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,7 +60,12 @@ export async function replaceTscAliasPaths(
   const replaceList = await Promise.all(
     files.map((file) =>
       OpenFilesLimit(() =>
-        replaceAlias(config, file, options?.resolveFullPaths)
+        replaceAlias(
+          config,
+          file,
+          options?.resolveFullPaths,
+          options?.resolveFullExtension
+        )
       )
     )
   );
@@ -116,7 +121,8 @@ export async function prepareSingleFileReplaceTscAliasPaths(
       config,
       filePath,
       fileContents,
-      options?.resolveFullPaths
+      options?.resolveFullPaths,
+      options?.resolveFullExtension
     );
   };
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -61,6 +61,7 @@ export interface ReplaceTscAliasPathsOptions {
   verbose?: boolean;
   debug?: boolean;
   resolveFullPaths?: boolean;
+  resolveFullExtension?: '.js' | '.mjs' | '.cjs';
   replacers?: string[];
   output?: IOutput;
   aliasTrie?: TrieNode<Alias>;


### PR DESCRIPTION
Hi, this library is all I need. Using it with esbuild is great combo. But I miss something

First, when the target files is minified version (esbuild minify=true), then It will not replace anything. Because minified version is look like this
```js
import"something";
import{X}from"something";
```
As you can see, there is no space after import and from statement. I add regex to cover this situation, please correct me is the regex can be simplified.

Second, when using `resolveFullPath` option, this library only search for `.js` extension. My project is full esm, it's using `.mjs`. So I create additional option to cover this, so It can be adjusted to search `.mjs` or `.cjs`. By default it will search `.js`. I don't know if it's the best way.