### PR TITLE
Docs: Update the "project" flag since "configFile" does not exist as a parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Here are all the available options:
   </thead>
   <tbody>
     <tr>
-      <td>configFile</td>
+      <td>project, p</td>
       <td>path to tsconfig.json</td>
       <td><code>'tsconfig.json'</code></td>
     </tr>


### PR DESCRIPTION
As per the options of the `tsc-alias` command, the correct parameter would be `project` instead of `configFile`, since the latter is only used internally. https://github.com/justkey007/tsc-alias/blob/de8a5bc03635f1823742b6b4c7614930f0ecfcf0/src/bin/index.ts#L10