### PR TITLE
fix: make `--inputglob` and `--outputcheck` work on their own

### DIFF
--- a/src/helpers/config.ts
+++ b/src/helpers/config.ts
@@ -148,9 +148,7 @@ export const loadConfig = (file: string, output: IOutput): ITSConfig => {
   if (TSCAliasConfig?.verbose) {
     config.verbose = TSCAliasConfig.verbose;
   }
-  if (TSCAliasConfig?.fileExtensions) {
-    config.fileExtensions = TSCAliasConfig.fileExtensions;
-  }
+  config.fileExtensions = TSCAliasConfig?.fileExtensions ?? {};
 
   const replacerFile = config.replacers?.pathReplacer?.file;
 


### PR DESCRIPTION
A command like `tsc-alias -p tsconfig.json --inputglob js --outputcheck js` currently fatals with
```
            fileExtensions.inputGlob = options.fileExtensions.inputGlob;
                                     ^

TypeError: Cannot set properties of undefined (setting 'inputGlob')
```
because the removed lines leave `fileExtensions` unset when used with a config that doesn't contain that field. (A workaround is to put a dummy `"tsc-alias": { "fileExtensions": {} }` in tsconfig.json.)