### PR TITLE
fix: Don't replace .d.ts paths

### DIFF
--- a/src/utils/trie.ts
+++ b/src/utils/trie.ts
@@ -12,7 +12,7 @@
  */
 
 /** */
-import { isAbsolute, normalize, relative, resolve } from 'path';
+import { isAbsolute, normalize, relative, resolve, parse, sep } from 'path';
 import { findBasePathOfAlias, relativeOutPathToConfigDir } from '../helpers';
 import { Alias, IProjectConfig, PathLike } from '../interfaces';
 
@@ -79,9 +79,21 @@ export class TrieNode<T> {
             prefix: alias.replace(/\*$/, ''),
             // Normalize paths.
             paths: paths[alias].map((path) => {
-              path = path
-                .replace(/\*$/, '')
-                .replace(/\.([mc])?ts(x)?$/, '.$1js$2');
+              path = path.replace(/\*$/, '');
+
+              const { dir, base } = parse(path);
+
+              const dotIndex = base.indexOf('.');
+              const name = base.slice(0, dotIndex);
+              const extension = base.slice(dotIndex);
+
+              const normalizedExtension = extension.replace(
+                /^\.([mc])?ts(x)?$/,
+                '.$1js$2'
+              );
+
+              path = dir + sep + name + normalizedExtension;
+
               if (isAbsolute(path)) {
                 path = relative(
                   resolve(config.configDir, config.baseUrl),

--- a/src/utils/trie.ts
+++ b/src/utils/trie.ts
@@ -87,10 +87,14 @@ export class TrieNode<T> {
               const name = base.slice(0, dotIndex);
               const extension = base.slice(dotIndex);
 
-              const normalizedExtension = extension.replace(
-                /^\.([mc])?ts(x)?$/,
-                '.$1js$2'
-              );
+              let normalizedExtension = extension;
+
+              if (!isDTS(extension)) {
+                normalizedExtension = extension.replace(
+                  /\.([mc])?ts(x)?$/,
+                  '.$1js$2'
+                );
+              }
 
               path = dir + sep + name + normalizedExtension;
 
@@ -125,4 +129,8 @@ export class TrieNode<T> {
     }
     return aliasTrie;
   }
+}
+
+function isDTS(extension: string): boolean {
+  return /\.d(\..*)?\.[mc]?ts(x)?$/.test(extension);
 }


### PR DESCRIPTION
Context: I have an alias written as `"@utils": ["./src/utils/index.d.mts"]` and it was being changed to `./src/utils/index.d.mjs` which broke resolution.

I know it's obviously niche to be using tsc-alias on already written `.d.ts` files but I'm of course typing someone else's code so plain `.ts` files don't make sense. I can see a few alternatives here:
1. Put this behind a flag `noRewritePaths` or something.
2. Test both `.d.mts` and `.d.mjs`
3. Just don't support this weird use case.

But I think this solution is pretty simple!