### PR TITLE
fix: bad baseUrl when project name matches folder

### DIFF
--- a/src/helpers/path.ts
+++ b/src/helpers/path.ts
@@ -34,11 +34,35 @@ function getProjectDirPathInOutDir(
   );
 
   // Find the longest path
-  return dirs.reduce(
-    (prev, curr) =>
-      prev.split('/').length > curr.split('/').length ? prev : curr,
-    dirs[0]
-  );
+  return getLongestProjectPath(outDir, projectDir, dirs);
+}
+
+/**
+ * Returns the `dir` that has the longest match with `posixOutput`.
+ *
+ * @example
+ * getLongestProjectPath(
+ *     '/project/path/lib',
+ *     'path',
+ *     ['/project/path/lib/project/path', '/project/path/lib/other/path'])
+ * // Returns '/project/path/lib/project/path' because 'project/path' matches more than 'other/path'
+ */
+function getLongestProjectPath(outDir, projectDir, dirs) {
+  const posixOutParts = outDir.replace(/\\/g, '/').split('/');
+  const lastIndex = posixOutParts.lastIndexOf(projectDir);
+  const result = dirs.reduce((longest, dir) => {
+    const parts = dir.split('/');
+    let length = 0;
+    for (let i = parts.length - 1; i >= 0; --i) {
+      if (parts[i] === posixOutParts[lastIndex - length]) {
+        ++length;
+      } else {
+        break;
+      }
+    }
+    return longest.matchLength > length ? longest : {matchLength: length, dir};
+  }, {matchLength: 0, dir: ''});
+  return result.dir;
 }
 
 /**


### PR DESCRIPTION
This will fix #205: When an aliased subdirectory has the same name as the project folder, tsc-alias can fail to replace import aliases, causing imports to fail at runtime.

For example, before the following would fail:
[
"/home/acorn/cloud/Projects/js/foony/services/games/pool/lib/services/games/pool", "/home/acorn/cloud/Projects/js/foony/services/games/pool/lib/shared/src/games/pool" ]

This is because the name of the import alias folder, "pool", matched the name of the project.