### PR TITLE
fix: do not activate baseurl mode

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,6 +85,12 @@ importers:
         specifier: ^4.9.5
         version: 4.9.5
 
+  projects/issue261:
+    dependencies:
+      redis:
+        specifier: ^4.7.0
+        version: 4.7.1
+
   projects/project1: {}
 
   projects/project10: {}
@@ -461,6 +467,35 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
+  '@redis/bloom@1.2.0':
+    resolution: {integrity: sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==}
+    peerDependencies:
+      '@redis/client': ^1.0.0
+
+  '@redis/client@1.6.1':
+    resolution: {integrity: sha512-/KCsg3xSlR+nCK8/8ZYSknYxvXHwubJrU82F3Lm1Fp6789VQ0/3RJKfsmRXjqfaTA++23CvC3hqmqe/2GEt6Kw==}
+    engines: {node: '>=14'}
+
+  '@redis/graph@1.1.1':
+    resolution: {integrity: sha512-FEMTcTHZozZciLRl6GiiIB4zGm5z5F3F6a6FZCyrfxdKOhFlGkiAqlexWMBzCi4DcRoyiOsuLfW+cjlGWyExOw==}
+    peerDependencies:
+      '@redis/client': ^1.0.0
+
+  '@redis/json@1.0.7':
+    resolution: {integrity: sha512-6UyXfjVaTBTJtKNG4/9Z8PSpKE6XgSyEb8iwaqDcy+uKrd/DGYHTWkUdnQDyzm727V7p21WUMhsqz5oy65kPcQ==}
+    peerDependencies:
+      '@redis/client': ^1.0.0
+
+  '@redis/search@1.2.0':
+    resolution: {integrity: sha512-tYoDBbtqOVigEDMAcTGsRlMycIIjwMCgD8eR2t0NANeQmgK/lvxNAvYyb6bZDD4frHRhIHkJu2TBRvB0ERkOmw==}
+    peerDependencies:
+      '@redis/client': ^1.0.0
+
+  '@redis/time-series@1.1.0':
+    resolution: {integrity: sha512-c1Q99M5ljsIuc4YdaCwfUEXsofakb9c8+Zse2qxTadu8TalLXuAESzLvFAvNVbkmSlvlzIQOLpBCmWI9wTOt+g==}
+    peerDependencies:
+      '@redis/client': ^1.0.0
+
   '@sinonjs/commons@1.8.6':
     resolution: {integrity: sha512-Ky+XkAkqPZSm3NLBeUng77EBQl3cmeJhITaGHdYH8kjVB+aun3S4XBRti2zt17mtt0mIUDiNxYeoJm6drVvBJQ==}
 
@@ -727,6 +762,10 @@ packages:
   cliui@7.0.4:
     resolution: {integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==}
 
+  cluster-key-slot@1.1.2:
+    resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
+    engines: {node: '>=0.10.0'}
+
   co@4.6.0:
     resolution: {integrity: sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==}
     engines: {iojs: '>= 1.0.0', node: '>= 0.12.0'}
@@ -953,6 +992,10 @@ packages:
     resolution: {integrity: sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==}
     engines: {node: '>=10'}
     deprecated: This package is no longer supported.
+
+  generic-pool@3.9.0:
+    resolution: {integrity: sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==}
+    engines: {node: '>= 4'}
 
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
@@ -1591,6 +1634,9 @@ packages:
     resolution: {integrity: sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==}
     engines: {node: '>= 0.10'}
 
+  redis@4.7.1:
+    resolution: {integrity: sha512-S1bJDnqLftzHXHP8JsT5II/CtHWQrASX5K96REjWjlmWKrviSOLWmM7QnRLstAWsu1VBBV1ffV6DzCvxNP0UJQ==}
+
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
@@ -1747,6 +1793,7 @@ packages:
   tar@6.2.1:
     resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
     engines: {node: '>=10'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   terminal-link@2.1.1:
     resolution: {integrity: sha512-un0FmiRUQNr5PJqy9kP7c40F5BOfpGlYTrxonDChEZB7pzZxRNp/bt+ymiy9/npwXya9KH99nJ/GXFIiUkYGFQ==}
@@ -2383,6 +2430,32 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
 
+  '@redis/bloom@1.2.0(@redis/client@1.6.1)':
+    dependencies:
+      '@redis/client': 1.6.1
+
+  '@redis/client@1.6.1':
+    dependencies:
+      cluster-key-slot: 1.1.2
+      generic-pool: 3.9.0
+      yallist: 4.0.0
+
+  '@redis/graph@1.1.1(@redis/client@1.6.1)':
+    dependencies:
+      '@redis/client': 1.6.1
+
+  '@redis/json@1.0.7(@redis/client@1.6.1)':
+    dependencies:
+      '@redis/client': 1.6.1
+
+  '@redis/search@1.2.0(@redis/client@1.6.1)':
+    dependencies:
+      '@redis/client': 1.6.1
+
+  '@redis/time-series@1.1.0(@redis/client@1.6.1)':
+    dependencies:
+      '@redis/client': 1.6.1
+
   '@sinonjs/commons@1.8.6':
     dependencies:
       type-detect: 4.0.8
@@ -2669,6 +2742,8 @@ snapshots:
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
 
+  cluster-key-slot@1.1.2: {}
+
   co@4.6.0: {}
 
   collect-v8-coverage@1.0.2: {}
@@ -2874,6 +2949,8 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
       wide-align: 1.1.5
+
+  generic-pool@3.9.0: {}
 
   gensync@1.0.0-beta.2: {}
 
@@ -3695,6 +3772,15 @@ snapshots:
     dependencies:
       resolve: 1.22.10
 
+  redis@4.7.1:
+    dependencies:
+      '@redis/bloom': 1.2.0(@redis/client@1.6.1)
+      '@redis/client': 1.6.1
+      '@redis/graph': 1.1.1(@redis/client@1.6.1)
+      '@redis/json': 1.0.7(@redis/client@1.6.1)
+      '@redis/search': 1.2.0(@redis/client@1.6.1)
+      '@redis/time-series': 1.1.0(@redis/client@1.6.1)
+
   require-directory@2.1.1: {}
 
   requires-port@1.0.0: {}
@@ -3837,7 +3923,7 @@ snapshots:
     dependencies:
       '@istanbuljs/schema': 0.1.3
       glob: 7.2.3
-      minimatch: 10.0.1
+      minimatch: 10.2.5
 
   throat@6.0.2: {}
 

--- a/projects/issue261/.gitignore
+++ b/projects/issue261/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+package-lock.json

--- a/projects/issue261/README.md
+++ b/projects/issue261/README.md
@@ -1,0 +1,71 @@
+# tsc-alias issue #261 — minimal reproduction
+
+Reproduction for **[justkey007/tsc-alias#261](https://github.com/justkey007/tsc-alias/issues/261)**,
+a regression introduced in **tsc-alias 1.9.0** (via [PR #259](https://github.com/justkey007/tsc-alias/pull/259)).
+
+## The bug
+
+When a source file has the **same base name as an npm package it imports**, tsc-alias
+1.9.0 rewrites the bare module specifier into a relative path pointing at the file itself.
+
+Given `src/redis.ts`:
+
+```ts
+import { createClient } from 'redis';
+const client = createClient();
+```
+
+| tsc-alias | compiled `dist/redis.js` | result |
+|-----------|--------------------------|--------|
+| **1.8.17** | `const redis_1 = require("redis");` | ✅ works |
+| **1.9.0**  | `const redis_1 = require("./redis");` | ❌ module requires itself |
+
+On 1.9.0 the module ends up requiring itself, so the named export is `undefined`
+at runtime:
+
+```
+TypeError: (0 , redis_1.createClient) is not a function
+```
+
+## Root cause
+
+This `tsconfig.json` uses `compilerOptions.paths` **without** `baseUrl`. `baseUrl`
+was deprecated in TypeScript 6.0, so we intentionally rely only on `paths` with
+relative mappings.
+
+PR #259 ("support ts 6 implicit baseURL") added logic in `src/helpers/config.ts`:
+when `paths` is set but `baseUrl` is not, it assigns `config.baseUrl = rootDir`.
+With a `baseUrl` now in effect, tsc-alias treats a **bare** specifier like `redis`
+as resolvable against the source dir, and because `src/redis.ts` exists it rewrites
+`require("redis")` → `require("./redis")`.
+
+Bare module specifiers (npm packages) should never be rewritten to relative paths —
+only aliases configured in `compilerOptions.paths` (here, `@app/*`) should be transformed.
+
+## How to reproduce
+
+```bash
+npm install
+npm run build          # tsc --noCheck && tsc-alias  (uses tsc-alias 1.9.0)
+grep require dist/redis.js
+#   => const redis_1 = require("./redis");   ❌
+
+node ./dist/redis.js
+#   => TypeError: (0 , redis_1.createClient) is not a function
+```
+
+### Side-by-side comparison (1.8.17 vs 1.9.0)
+
+```bash
+./repro.sh
+```
+
+This installs each version in turn, rebuilds, and prints the `require()` line plus
+the runtime result for both.
+
+## Environment
+
+- tsc-alias **1.9.0** (regressed) — **1.8.17** works
+- TypeScript **6.0.3**
+- CommonJS output
+- `tsconfig.json` intentionally has **no `baseUrl`**

--- a/projects/issue261/package.json
+++ b/projects/issue261/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "tsc-alias-issue-261-repro",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Minimal reproduction for tsc-alias issue #261 (bare npm import rewritten to relative path when a local file shares the module name)",
+  "scripts": {
+    "build": "pnpm install && tsc && tsc-alias",
+    "start": "npm run build && node ./dist/redis.js",
+    "repro": "./repro.sh"
+  },
+  "dependencies": {
+    "redis": "^4.7.0"
+  }
+}

--- a/projects/issue261/repro.sh
+++ b/projects/issue261/repro.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Demonstrates the regression side by side on tsc-alias 1.9.0 vs 1.8.17.
+set -euo pipefail
+
+echo "Installing dependencies..."
+npm install --silent
+
+run() {
+  local version="$1"
+  echo
+  echo "=================================================================="
+  echo " tsc-alias@${version}"
+  echo "=================================================================="
+  npm install --silent --no-save "tsc-alias@${version}"
+  rm -rf dist
+  npx tsc --noCheck
+  npx tsc-alias
+  echo "--- compiled dist/redis.js require() line ---"
+  grep 'require(' dist/redis.js
+  echo "--- runtime ---"
+  if node -e "require('./dist/redis.js'); console.log('OK: package resolved correctly')" 2>&1; then
+    :
+  else
+    echo "FAILED: module required itself instead of the npm package"
+  fi
+}
+
+run "1.8.17"   # expected: require("redis")  -> works
+run "1.9.0"    # regressed: require("./redis") -> TypeError at runtime

--- a/projects/issue261/src/redis.ts
+++ b/projects/issue261/src/redis.ts
@@ -1,0 +1,7 @@
+// A local source file whose base name (`redis`) collides with the
+// npm package it imports. This collision is what triggers the bug.
+import { createClient } from 'redis';
+
+const client = createClient();
+
+export { client };

--- a/projects/issue261/tsconfig.json
+++ b/projects/issue261/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "target": "es2020",
+    "module": "commonjs",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "ignoreDeprecations": "6.0",
+    "paths": {
+      "@app/*": ["./src/*"]
+    }
+  },
+  "include": ["src"],
+  "exclude": ["node_modules"]
+}

--- a/src/helpers/config.ts
+++ b/src/helpers/config.ts
@@ -173,7 +173,6 @@ export const loadConfig = (
       rootDir,
       'compilerOptions.rootDir is required with implicit baseUrl'
     );
-    config.baseUrl = rootDir;
     const resolvedRootDir = resolve(configDir, rootDir);
     for (const key in config.paths) {
       config.paths[key] = config.paths[key].map((path) =>

--- a/tests/test.spec.ts
+++ b/tests/test.spec.ts
@@ -38,8 +38,8 @@ import
 const notAnImport = unimport('something');
 `;
 
-function runTestProject(projectNumber: number) {
-  const projectDir = join(projectsRoot, `project${projectNumber}`);
+function runTestProject(projectName: string) {
+  const projectDir = join(projectsRoot, projectName);
   rimraf.sync(join(projectDir, 'dist'));
   const { code, stdout, stderr } = shell.exec('npm start', {
     cwd: projectDir,
@@ -47,7 +47,7 @@ function runTestProject(projectNumber: number) {
   });
 
   if (code !== 0) {
-    console.error(`Project ${projectNumber} failed`);
+    console.error(`Project ${projectName} failed`);
     console.error('stdout:\n', stdout);
     console.error('stderr:\n', stderr);
   }
@@ -91,11 +91,13 @@ it(`Import regex does not match edge cases from keywords in strings`, function (
 });
 
 // Run tests on projects. 9-11 are for testing fullpath file resolution
-[
+it.each([
   1, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 20, 21, 22, 23,
   24, 25, 26
-].forEach((value) => {
-  it(`Project ${value} runs after alias resolution`, () => {
-    runTestProject(value);
-  });
+])('Project %d runs after alias resolution', (value) => {
+  runTestProject(`project${value}`);
+});
+
+it.each([261])('issue %d should work correctly', (value) => {
+  runTestProject(`issue${value}`);
 });


### PR DESCRIPTION
Fix for #261 and likely #259

Tooling do not work anymore with pnpm 11, and would deserve some simplification/rethinking.