### PR TITLE
fix: capture dynamic imports containing import attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,17 +91,12 @@ Here are all the available options:
       <td><code>tsconfig.compilerOptions.outDir</code></td>
     </tr>
     <tr>
-      <td>declarationDir</td>
-      <td>Works the same as outDir but for declarationDir</td>
-      <td><code>tsconfig.compilerOptions.declarationDir</code></td>
-    </tr>
-    <tr>
-      <td>resolveFullPaths</td>
+      <td>resolve-full-paths</td>
       <td>Attempt to replace incomplete import paths (those not ending in <code>.js</code>) with fully resolved paths (for ECMAScript Modules compatibility)</td>
       <td><code>false</code></td>
     </tr>
     <tr>
-      <td>resolveFullExtension</td>
+      <td>resolve-full-extension</td>
       <td>Allows you to specify the extension of incomplete import paths, works with <code>resolveFullPaths</code></td>
       <td><code>'.js' | '.mjs' | '.cjs'</code></td>
     </tr>
@@ -131,7 +126,7 @@ Here are all the available options:
       <td><code>new Output(options.verbose)</code></td>
     </tr>
     <tr>
-      <td>fileExtensions</td>
+      <td>file-extensions</td>
       <td>Overwrite file extensions tsc-alias will use to scan and resolve files.</td>
       <td><code>undefined</code></td>
     </tr>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,6 +85,19 @@ importers:
         specifier: ^4.9.5
         version: 4.9.5
 
+  projects/issue247:
+    dependencies:
+      debug:
+        specifier: ^4.4.3
+        version: 4.4.3
+    devDependencies:
+      '@types/debug':
+        specifier: ^4.1.13
+        version: 4.1.13
+      typescript:
+        specifier: ^7.0.2
+        version: 7.0.2
+
   projects/issue261:
     dependencies:
       redis:
@@ -546,6 +559,9 @@ packages:
   '@types/babel__traverse@7.20.7':
     resolution: {integrity: sha512-dkO5fhS7+/oos4ciWxyEyjWe48zmG6wbCheo/G2ZnHx4fs3EU6YC6UM8rk56gAjNJ9P3MTH2jo5jb92/K6wbng==}
 
+  '@types/debug@4.1.13':
+    resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
   '@types/glob@7.2.0':
     resolution: {integrity: sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==}
 
@@ -572,6 +588,9 @@ packages:
 
   '@types/minimatch@5.1.2':
     resolution: {integrity: sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==}
+
+  '@types/ms@2.1.0':
+    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
   '@types/node@16.18.126':
     resolution: {integrity: sha512-OTcgaiwfGFBKacvfwuHzzn1KLxH/er8mluiy8/uM3sGXHaRe73RrSIj01jow9t4kJEW633Ov+cOexXeiApTyAw==}
@@ -958,8 +977,8 @@ packages:
     resolution: {integrity: sha512-X5eWTSXO/BJmpdIKCRuKUgSCgAN0OwliVK3yPKbwIWU1Tdw5BRajxlzMidvh+gwko9AfQ9zIj52pzF91Q3YAvQ==}
     engines: {node: '>=10'}
 
-  debug@4.4.0:
-    resolution: {integrity: sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==}
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
     peerDependencies:
       supports-color: '*'
@@ -2169,7 +2188,7 @@ snapshots:
       '@babel/traverse': 7.27.0
       '@babel/types': 7.27.0
       convert-source-map: 2.0.0
-      debug: 4.4.0
+      debug: 4.4.3
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -2318,7 +2337,7 @@ snapshots:
       '@babel/parser': 7.27.0
       '@babel/template': 7.27.0
       '@babel/types': 7.27.0
-      debug: 4.4.0
+      debug: 4.4.3
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -2644,6 +2663,10 @@ snapshots:
     dependencies:
       '@babel/types': 7.27.0
 
+  '@types/debug@4.1.13':
+    dependencies:
+      '@types/ms': 2.1.0
+
   '@types/glob@7.2.0':
     dependencies:
       '@types/minimatch': 5.1.2
@@ -2676,6 +2699,8 @@ snapshots:
       pretty-format: 27.5.1
 
   '@types/minimatch@5.1.2': {}
+
+  '@types/ms@2.1.0': {}
 
   '@types/node@16.18.126': {}
 
@@ -2782,7 +2807,7 @@ snapshots:
 
   agent-base@6.0.2:
     dependencies:
-      debug: 4.4.0
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -2999,7 +3024,7 @@ snapshots:
       whatwg-mimetype: 2.3.0
       whatwg-url: 8.7.0
 
-  debug@4.4.0:
+  debug@4.4.3:
     dependencies:
       ms: 2.1.3
 
@@ -3249,14 +3274,14 @@ snapshots:
     dependencies:
       '@tootallnate/once': 3.0.1
       agent-base: 6.0.2
-      debug: 4.4.0
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.4.0
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -3267,7 +3292,7 @@ snapshots:
   i18n@0.15.1:
     dependencies:
       '@messageformat/core': 3.4.0
-      debug: 4.4.0
+      debug: 4.4.3
       fast-printf: 1.6.10
       make-plural: 7.5.0
       math-interval-parser: 2.0.1
@@ -3347,7 +3372,7 @@ snapshots:
 
   istanbul-lib-source-maps@4.0.1:
     dependencies:
-      debug: 4.4.0
+      debug: 4.4.3
       istanbul-lib-coverage: 3.2.2
       source-map: 0.6.1
     transitivePeerDependencies:

--- a/projects/issue247/package.json
+++ b/projects/issue247/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "tsc-alias-issue-247-repro",
+  "version": "1.0.0",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "build": "pnpm install && tsc && tsc-alias --resolve-full-paths",
+    "start": "npm run build && node ./dist/index.js"
+  },
+  "dependencies": {
+    "debug": "^4.4.3"
+  },
+  "devDependencies": {
+    "@types/debug": "^4.1.13",
+    "typescript": "^7.0.2"
+  }
+}

--- a/projects/issue247/src/data.json
+++ b/projects/issue247/src/data.json
@@ -1,0 +1,3 @@
+{
+  "firstname": "John"
+}

--- a/projects/issue247/src/debug.ts
+++ b/projects/issue247/src/debug.ts
@@ -1,0 +1,9 @@
+import debug from 'debug';
+
+export const logger = debug('amqp-gateway');
+
+logger.log = console.log.bind(console);
+
+export interface Person {
+  firstname: string;
+}

--- a/projects/issue247/src/index.ts
+++ b/projects/issue247/src/index.ts
@@ -1,0 +1,14 @@
+import { Person } from '@app/debug';
+import { logger } from './debug';
+const person: Person = { firstname: 'James' };
+
+export interface Book {
+  author: Person;
+}
+
+async function run() {
+  const { default: data } = await import('@app/data.json', { with: { type: 'json' } });
+  logger.log(`Hello ${(data as Person).firstname || person.firstname}`);
+}
+
+run();

--- a/projects/issue247/tsconfig.json
+++ b/projects/issue247/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "target": "es2020",
+    "module": "esnext",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "paths": {
+      "@app/*": ["./src/*"]
+    }
+  },
+  "include": ["src"],
+  "exclude": ["node_modules"]
+}

--- a/src/utils/import-path-resolver.ts
+++ b/src/utils/import-path-resolver.ts
@@ -37,7 +37,7 @@ const importString = `(?:${anyQuote}${pathStringContent}${anyQuote})`;
 // Separate patterns for each style of import statement,
 // wrapped in non-capturing groups,
 // so that they can be strung together in one big pattern.
-const funcStyle = `(?:\\b(?:import|require)\\s*\\(\\s*(\\/\\*.*\\*\\/\\s*)?${importString}\\s*\\))`;
+const funcStyle = `(?:\\b(?:import|require)\\s*\\(\\s*(\\/\\*.*\\*\\/\\s*)?${importString}(?:\\s*,[\\s\\S]*?)?\\s*\\))`;
 const globalStyle = `(?:\\bimport\\s+${importString})`;
 const globalMinimizedStyle = `(?:\\bimport${importString})`;
 const fromStyle = `(?:\\bfrom\\s+${importString})`;
@@ -96,19 +96,22 @@ class ImportPathResolver {
    * If no corresponding file can be found, return the original path.
    */
   private resolveFullPath(importPath: string, ext = '.js') {
+    // Si l'importation cible explicitement un fichier JSON, on doit conserver l'extension .json
+    const targetExt = importPath.endsWith('.json') ? '.json' : ext;
+
     // If bare import or already a full path import
-    if (!importPath.startsWith('.') || importPath.match(new RegExp(`\${ext}$`))) {
+    if (!importPath.startsWith('.') || importPath.match(new RegExp(`\\${targetExt}$`))) {
       return importPath;
     }
     // Try adding the extension (if not obviously a directory)
     if (!importPath.match(/[/\\]$/)) {
-      const asFilePath = `${importPath}${ext}`;
+      const asFilePath = `${importPath}${targetExt}`;
       if (existsSync(resolve(this.sourceDir, asFilePath))) {
         return asFilePath;
       }
     }
-    // Assume the path is a folder; try adding index.js
-    let asFilePath = join(importPath, 'index' + ext);
+    // Assume the path is a folder; try adding index.js / index.json
+    let asFilePath = join(importPath, 'index' + targetExt);
     if ((importPath.startsWith('./') || importPath === '.') && !asFilePath.startsWith('./')) {
       asFilePath = './' + asFilePath;
     }

--- a/tests/import-path-resolver.spec.ts
+++ b/tests/import-path-resolver.spec.ts
@@ -1,9 +1,4 @@
-import { join } from 'path';
-import * as rimraf from 'rimraf';
-import * as shell from 'shelljs';
 import { newImportStatementRegex, newStringRegex } from '../src/utils';
-
-const projectsRoot = join(__dirname, '../projects');
 
 /**
  * Sample JavaScript code with a bunch of require/import
@@ -38,23 +33,6 @@ import
 const notAnImport = unimport('something');
 `;
 
-function runTestProject(projectName: string) {
-  const projectDir = join(projectsRoot, projectName);
-  rimraf.sync(join(projectDir, 'dist'));
-  const { code, stdout, stderr } = shell.exec('npm start', {
-    cwd: projectDir,
-    silent: true
-  });
-
-  if (code !== 0) {
-    console.error(`Project ${projectName} failed`);
-    console.error('stdout:\n', stdout);
-    console.error('stderr:\n', stderr);
-  }
-
-  expect(code).toEqual(0);
-}
-
 it(`Import regex matches import statements`, () => {
   const expectedImportPaths = sampleImportStatements.match(/(\d+)/g) as string[];
 
@@ -84,14 +62,15 @@ it(`Import regex does not match edge cases from keywords in strings`, function (
   expect(newImportStatementRegex().exec(testCase)?.[0]).toBeUndefined();
 });
 
-// Run tests on projects. 9-11 are for testing fullpath file resolution
-it.each([1, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 20, 21, 22, 23, 24, 25, 26])(
-  'Project %d runs after alias resolution',
-  (value) => {
-    runTestProject(`project${value}`);
-  }
-);
+it(`Should correctly extract ONLY the file path even with JSON attributes`, function () {
+  const statement = `await import('@app/data.json', { with: { type: 'json' } });`;
+  const match = statement.match(newStringRegex());
+  expect(match?.groups?.path).toBe('@app/data.json');
+});
 
-it.each([261, 263, 265])('issue %d should work correctly', (value) => {
-  runTestProject(`issue${value}`);
+it(`Import regex matches dynamic import with options/attributes`, function () {
+  const statement = `const { default: data } = await import('@app/data.json', { with: { type: 'json' } });`;
+  const matches = statement.match(newImportStatementRegex('g'));
+  expect(matches).toBeTruthy();
+  expect(matches?.[0]).toBe(`import('@app/data.json', { with: { type: 'json' } })`);
 });

--- a/tests/projects-test.spec.ts
+++ b/tests/projects-test.spec.ts
@@ -1,0 +1,34 @@
+import { join } from 'path';
+import * as rimraf from 'rimraf';
+import * as shell from 'shelljs';
+
+const projectsRoot = join(__dirname, '../projects');
+
+function runTestProject(projectName: string) {
+  const projectDir = join(projectsRoot, projectName);
+  rimraf.sync(join(projectDir, 'dist'));
+  const { code, stdout, stderr } = shell.exec('npm start', {
+    cwd: projectDir,
+    silent: true
+  });
+
+  if (code !== 0) {
+    console.error(`Project ${projectName} failed`);
+    console.error('stdout:\n', stdout);
+    console.error('stderr:\n', stderr);
+  }
+
+  expect(code).toEqual(0);
+}
+
+// Run tests on projects. 9-11 are for testing fullpath file resolution
+it.each([1, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 20, 21, 22, 23, 24, 25, 26])(
+  'Project %d runs after alias resolution',
+  (value) => {
+    runTestProject(`project${value}`);
+  }
+);
+
+it.each([261, 263, 265])('issue %d should work correctly', (value) => {
+  runTestProject(`issue${value}`);
+});


### PR DESCRIPTION
Allow options/attributes (e.g. { with: { type: 'json' } }) in funcStyle import regex pattern.

Fixes #247