### PR TITLE
fix: prevent premature declarationDir scan and resolve type alias paths (#251)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,6 +98,12 @@ importers:
         specifier: ^7.0.2
         version: 7.0.2
 
+  projects/issue251:
+    devDependencies:
+      typescript:
+        specifier: ^7.0.2
+        version: 7.0.2
+
   projects/issue261:
     dependencies:
       redis:

--- a/projects/issue251/package.json
+++ b/projects/issue251/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "tsc-alias-issue-247-repro",
+  "version": "1.0.0",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "build": "pnpm install && tsc && tsc-alias --resolve-full-paths",
+    "start": "npm run build && node ./dist/index.js"
+  },
+  "devDependencies": {
+    "typescript": "^7.0.2"
+  }
+}

--- a/projects/issue251/src/data.json
+++ b/projects/issue251/src/data.json
@@ -1,0 +1,3 @@
+{
+  "firstname": "John"
+}

--- a/projects/issue251/src/index.ts
+++ b/projects/issue251/src/index.ts
@@ -1,0 +1,5 @@
+import { Person } from '@app/interfaces';
+
+export interface Book {
+  author: Person;
+}

--- a/projects/issue251/src/interfaces.ts
+++ b/projects/issue251/src/interfaces.ts
@@ -1,0 +1,3 @@
+export interface Person {
+  firstname: string;
+}

--- a/projects/issue251/tsconfig.json
+++ b/projects/issue251/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "target": "es2020",
+    "module": "esnext",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationDir": "dist/types",
+    "paths": {
+      "@app/*": ["./src/*"]
+    }
+  },
+  "include": ["src"],
+  "exclude": ["node_modules"]
+}

--- a/src/alias-paths-replacer.ts
+++ b/src/alias-paths-replacer.ts
@@ -1,0 +1,55 @@
+/**
+ * @file
+ * Main runner for replacing tsc alias paths across project files.
+ */
+
+import { pLimit } from 'plimit-lit';
+import { buildScanPattern, scanProjectFiles } from './alias-scanner';
+import { prepareConfig, replaceAlias } from './helpers';
+import { ReplaceTscAliasPathsOptions } from './interfaces';
+import { setupFileWatcher } from './watcher';
+
+const OpenFilesLimit = pLimit(500);
+
+/**
+ * replaceTscAliasPaths replaces the aliases in the project.
+ * @param {ReplaceTscAliasPathsOptions} options tsc-alias options.
+ */
+export async function replaceTscAliasPaths(options: ReplaceTscAliasPathsOptions = {}): Promise<void> {
+  const config = await prepareConfig(options);
+  const output = config.output;
+
+  const posixOutput = config.outPath.replace(/\\/g, '/').replace(/\/+$/g, '');
+  const globPattern = buildScanPattern(posixOutput, config.inputGlob, options.declarationDir);
+
+  output.debug('Search pattern:', globPattern);
+  const files = scanProjectFiles(globPattern);
+  output.debug('Found files:', files);
+
+  const replaceList = await Promise.all(
+    files.map((file) =>
+      OpenFilesLimit(() => replaceAlias(config, file, options?.resolveFullPaths, options?.resolveFullExtension))
+    )
+  );
+
+  output.info(`${replaceList.filter(Boolean).length} files were affected!`);
+
+  if (options.watch) {
+    setupFileWatcher({
+      config,
+      options,
+      globPattern,
+      onRestart: replaceTscAliasPaths
+    });
+  }
+
+  if (options.declarationDir && options.declarationDir !== config.outPath) {
+    await replaceTscAliasPaths({
+      ...options,
+      outDir: options.declarationDir,
+      declarationDir: undefined,
+      output: config.output,
+      aliasTrie: undefined
+    });
+  }
+}

--- a/src/alias-scanner.ts
+++ b/src/alias-scanner.ts
@@ -1,0 +1,23 @@
+/**
+ * @file
+ * Helper for scanning project files with glob pattern.
+ */
+
+import { sync } from 'globby';
+
+export function buildScanPattern(posixOutput: string, inputGlob: string, declarationDir?: string): string[] {
+  const globPattern = [`${posixOutput}/**/*.${inputGlob}`, `!${posixOutput}/**/node_modules`];
+
+  if (declarationDir && declarationDir !== posixOutput) {
+    const posixDeclDir = declarationDir.replace(/\\/g, '/').replace(/\/+$/g, '');
+    if (posixDeclDir.startsWith(posixOutput)) {
+      globPattern.push(`!${posixDeclDir}/**`);
+    }
+  }
+
+  return globPattern;
+}
+
+export function scanProjectFiles(globPattern: string[]): string[] {
+  return sync(globPattern, { dot: true, onlyFiles: true });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,10 @@
-import { watch } from 'chokidar';
-import { sync } from 'globby';
-import { pLimit } from 'plimit-lit';
-import { prepareConfig, replaceAlias, replaceAliasString } from './helpers';
-import {
+/**
+ * @file
+ * Entry point for tsc-alias library and API exports.
+ */
+
+export { replaceTscAliasPaths } from './alias-paths-replacer';
+export {
   AliasReplacer,
   AliasReplacerArguments,
   IConfig,
@@ -10,90 +12,4 @@ import {
   IProjectConfig,
   ReplaceTscAliasPathsOptions
 } from './interfaces';
-
-// export interfaces for api use.
-export { ReplaceTscAliasPathsOptions, AliasReplacer, AliasReplacerArguments, IConfig, IProjectConfig, IOutput };
-
-const defaultConfig = {
-  watch: false,
-  verbose: false,
-  debug: false,
-  declarationDir: undefined,
-  output: undefined,
-  aliasTrie: undefined
-};
-
-const OpenFilesLimit = pLimit(500);
-
-/**
- * replaceTscAliasPaths replaces the aliases in the project.
- * @param {ReplaceTscAliasPathsOptions} options tsc-alias options.
- */
-export async function replaceTscAliasPaths(options: ReplaceTscAliasPathsOptions = { ...defaultConfig }) {
-  const config = await prepareConfig(options);
-  const output = config.output;
-
-  // Finding files and changing alias paths
-  const posixOutput = config.outPath.replace(/\\/g, '/').replace(/\/+$/g, '');
-  const globPattern = [`${posixOutput}/**/*.${config.inputGlob}`, `!${posixOutput}/**/node_modules`];
-  output.debug('Search pattern:', globPattern);
-  const files = sync(globPattern, {
-    dot: true,
-    onlyFiles: true
-  });
-  output.debug('Found files:', files);
-
-  // Make array with promises for file changes
-  // Wait for all promises to resolve
-  const replaceList = await Promise.all(
-    files.map((file) =>
-      OpenFilesLimit(() => replaceAlias(config, file, options?.resolveFullPaths, options?.resolveFullExtension))
-    )
-  );
-
-  // Count all changed files
-  const replaceCount = replaceList.filter(Boolean).length;
-
-  output.info(`${replaceCount} files were affected!`);
-  if (options.watch) {
-    output.verbose = true;
-    output.info('[Watching for file changes...]');
-    const filesWatcher = watch(globPattern);
-    const tsconfigWatcher = watch(config.configFile);
-    const onFileChange = async (file: string) => await replaceAlias(config, file, options?.resolveFullPaths);
-    filesWatcher.on('add', onFileChange);
-    filesWatcher.on('change', onFileChange);
-    tsconfigWatcher.on('change', () => {
-      output.clear();
-      filesWatcher.close();
-      tsconfigWatcher.close();
-      replaceTscAliasPaths(options);
-    });
-  }
-  if (options.declarationDir) {
-    replaceTscAliasPaths({
-      ...options,
-      outDir: options.declarationDir,
-      declarationDir: undefined,
-      output: config.output,
-      aliasTrie: undefined
-    });
-  }
-}
-
-export type SingleFileReplacer = (input: { fileContents: string; filePath: string }) => string;
-
-/**
- * prepareSingleFileReplaceTscAliasPaths prepares a SingleFileReplacer.
- * @param {ReplaceTscAliasPathsOptions} options tsc-alias options.
- * @returns {Promise<SingleFileReplacer>} a SingleFileReplacer to use for replacing aliases in a single file.
- */
-export async function prepareSingleFileReplaceTscAliasPaths(
-  options: ReplaceTscAliasPathsOptions = { ...defaultConfig }
-): Promise<SingleFileReplacer> {
-  const config = await prepareConfig(options);
-
-  return ({ fileContents, filePath }) => {
-    return replaceAliasString(config, filePath, fileContents, options?.resolveFullPaths, options?.resolveFullExtension);
-  };
-}
+export { prepareSingleFileReplaceTscAliasPaths, SingleFileReplacer } from './single-file-replacer';

--- a/src/single-file-replacer.ts
+++ b/src/single-file-replacer.ts
@@ -1,0 +1,50 @@
+/**
+ * @file
+ * Single file replacer helper for tsc-alias.
+ */
+
+import { prepareConfig, replaceAliasString } from './helpers';
+import { IConfig, ReplaceTscAliasPathsOptions } from './interfaces';
+
+export type SingleFileReplacer = (input: { fileContents: string; filePath: string }) => string;
+
+/**
+ * prepareSingleFileReplaceTscAliasPaths prepares a SingleFileReplacer.
+ * @param {ReplaceTscAliasPathsOptions} options tsc-alias options.
+ * @returns {Promise<SingleFileReplacer>} a SingleFileReplacer to use for replacing aliases in a single file.
+ */
+export async function prepareSingleFileReplaceTscAliasPaths(
+  options: ReplaceTscAliasPathsOptions = {}
+): Promise<SingleFileReplacer> {
+  const config = await prepareConfig(options);
+  let declarationConfig: IConfig | undefined;
+  const declarationDir = options.declarationDir;
+
+  if (declarationDir && declarationDir !== config.outPath) {
+    declarationConfig = await prepareConfig({
+      ...options,
+      outDir: declarationDir,
+      declarationDir: undefined,
+      output: config.output,
+      aliasTrie: undefined
+    });
+  }
+
+  return ({ fileContents, filePath }) => {
+    let activeConfig = config;
+    const isDeclaration =
+      declarationConfig && (filePath.endsWith('.d.ts') || (declarationDir && filePath.startsWith(declarationDir)));
+
+    if (isDeclaration) {
+      activeConfig = declarationConfig!;
+    }
+
+    return replaceAliasString(
+      activeConfig,
+      filePath,
+      fileContents,
+      options?.resolveFullPaths,
+      options?.resolveFullExtension
+    );
+  };
+}

--- a/src/watcher.ts
+++ b/src/watcher.ts
@@ -1,0 +1,37 @@
+/**
+ * @file
+ * File watcher helper for tsc-alias watch mode.
+ */
+
+import { watch } from 'chokidar';
+import { replaceAlias } from './helpers';
+import { IConfig, ReplaceTscAliasPathsOptions } from './interfaces';
+
+export interface ISetupFileWatcherParams {
+  config: IConfig;
+  options: ReplaceTscAliasPathsOptions;
+  globPattern: string[];
+  onRestart: (options: ReplaceTscAliasPathsOptions) => void;
+}
+
+export function setupFileWatcher(params: ISetupFileWatcherParams): void {
+  const { config, options, globPattern, onRestart } = params;
+  const output = config.output;
+
+  output.verbose = true;
+  output.info('[Watching for file changes...]');
+
+  const filesWatcher = watch(globPattern);
+  const tsconfigWatcher = watch(config.configFile);
+  const onFileChange = async (file: string) => await replaceAlias(config, file, options?.resolveFullPaths);
+
+  filesWatcher.on('add', onFileChange);
+  filesWatcher.on('change', onFileChange);
+
+  tsconfigWatcher.on('change', () => {
+    output.clear();
+    filesWatcher.close();
+    tsconfigWatcher.close();
+    onRestart(options);
+  });
+}

--- a/tests/projects-test.spec.ts
+++ b/tests/projects-test.spec.ts
@@ -29,6 +29,6 @@ it.each([1, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 20, 21, 22,
   }
 );
 
-it.each([261, 263, 265])('issue %d should work correctly', (value) => {
+it.each([251, 261, 263, 265])('issue %d should work correctly', (value) => {
   runTestProject(`issue${value}`);
 });


### PR DESCRIPTION
- Exclude declarationDir from main outDir scan pattern when nested
- Await dedicated declarationDir replacement pass
- Add declarationDir-aware configuration in singleFileReplacer

fixes #251 