### PR TITLE
fix: accurately detect project dir in outDir using ancestor suffix matching (#205)

### DIFF
--- a/src/helpers/path-matcher.ts
+++ b/src/helpers/path-matcher.ts
@@ -1,0 +1,43 @@
+/**
+ * @file
+ * Ancestor suffix match helper for identifying project directory in output folder.
+ */
+
+interface IPathMatch {
+  matchLength: number;
+  dir: string;
+}
+
+function calculateMatchLength(dirParts: string[], posixOutParts: string[], lastIndex: number): number {
+  let length = 0;
+  for (let i = dirParts.length - 1; i >= 0; --i) {
+    if (dirParts[i] !== posixOutParts[lastIndex - length]) {
+      break;
+    }
+    length++;
+  }
+  return length;
+}
+
+/**
+ * Selects the path with the highest ancestor suffix match against the project directory.
+ */
+export function selectBestProjectPath(outDir: string, projectDir: string, dirs: string[]): string | undefined {
+  if (dirs.length === 0) return undefined;
+  const posixOutParts = outDir.replace(/\\/g, '/').split('/');
+  const lastIndex = posixOutParts.lastIndexOf(projectDir);
+
+  const bestMatch = dirs.reduce<IPathMatch>(
+    (longest, dir) => {
+      const parts = dir.split('/');
+      const length = calculateMatchLength(parts, posixOutParts, lastIndex);
+      if (length > longest.matchLength) {
+        return { matchLength: length, dir };
+      }
+      return longest;
+    },
+    { matchLength: 0, dir: dirs[0] }
+  );
+
+  return bestMatch.dir;
+}

--- a/src/helpers/path-project.ts
+++ b/src/helpers/path-project.ts
@@ -6,14 +6,8 @@
 import { sync } from 'globby';
 import { relative } from 'path';
 import { IProjectConfig } from '../interfaces';
+import { selectBestProjectPath } from './path-matcher';
 import normalizePath = require('normalize-path');
-
-function selectLongestPath(prev: string, curr: string): string {
-  if (prev.split('/').length > curr.split('/').length) {
-    return prev;
-  }
-  return curr;
-}
 
 /**
  * getProjectDirPathInOutDir finds the configDirInOutPath.
@@ -35,7 +29,7 @@ export function getProjectDirPathInOutDir(outDir: string, projectDir: string): s
     }
   );
 
-  return dirs.reduce(selectLongestPath, dirs[0]);
+  return selectBestProjectPath(outDir, projectDir, dirs);
 }
 
 /**

--- a/tests/path-matcher.spec.ts
+++ b/tests/path-matcher.spec.ts
@@ -1,0 +1,41 @@
+import { selectBestProjectPath } from '../src/helpers/path-matcher';
+
+describe('selectBestProjectPath', () => {
+  it('should return undefined when dirs list is empty', () => {
+    const result = selectBestProjectPath('/app/project/dist', 'project', []);
+    expect(result).toBeUndefined();
+  });
+
+  it('should select single matching project path', () => {
+    const outDir = '/app/my-project/dist';
+    const projectDir = 'my-project';
+    const dirs = ['/app/my-project/dist/my-project'];
+
+    const result = selectBestProjectPath(outDir, projectDir, dirs);
+    expect(result).toBe('/app/my-project/dist/my-project');
+  });
+
+  it('should select correct project path when an aliased dependency shares the project folder name', () => {
+    const outDir = '/home/user/workspace/services/games/pool/lib';
+    const projectDir = 'pool';
+    const dirs = [
+      '/home/user/workspace/services/games/pool/lib/shared/src/games/pool',
+      '/home/user/workspace/services/games/pool/lib/services/games/pool'
+    ];
+
+    const result = selectBestProjectPath(outDir, projectDir, dirs);
+    expect(result).toBe('/home/user/workspace/services/games/pool/lib/services/games/pool');
+  });
+
+  it('should work with Windows backslashes in outDir', () => {
+    const outDir = 'C:\\Projects\\services\\games\\pool\\lib';
+    const projectDir = 'pool';
+    const dirs = [
+      'C:/Projects/services/games/pool/lib/shared/src/games/pool',
+      'C:/Projects/services/games/pool/lib/services/games/pool'
+    ];
+
+    const result = selectBestProjectPath(outDir, projectDir, dirs);
+    expect(result).toBe('C:/Projects/services/games/pool/lib/services/games/pool');
+  });
+});


### PR DESCRIPTION
- Match ancestor path segments from target folder instead of raw path depth
- Prevent false positives when shared subdirectories share the project folder name
- Add comprehensive non-regression unit tests for path matching

Fixes #205